### PR TITLE
refactor(gkplus): remove dead with_dim_dummy branch from item_count

### DIFF
--- a/src/gplus_trees/g_k_plus/g_k_plus_base.py
+++ b/src/gplus_trees/g_k_plus/g_k_plus_base.py
@@ -160,12 +160,7 @@ class GKPlusTreeBase(
         """Create an empty tree of the same type, forwarding *l_factor*."""
         return type(self)(l_factor=self.l_factor)
 
-    def item_count(self, with_dim_dummy: bool = False) -> int:
-        if with_dim_dummy:
-            if self.item_cnt_ge_dummy is None:
-                return self.get_item_count_ge_dummy()
-            return self.item_cnt_ge_dummy
-
+    def item_count(self) -> int:
         if self.item_cnt is None:
             return self.get_tree_item_count()
         return self.item_cnt


### PR DESCRIPTION
## Why

`GKPlusTreeBase.item_count(with_dim_dummy=True)` referenced `self.item_cnt_ge_dummy` and `self.get_item_count_ge_dummy()`, neither of which exists — commit c65ea55 removed both as unused but left this branch behind. Any call with `with_dim_dummy=True` raised `AttributeError`. Reinstating the counting would re-introduce a deliberately removed feature, so the dead branch goes instead.

## What

- Drop the `with_dim_dummy` parameter and the dead branch from `item_count()` in `src/gplus_trees/g_k_plus/g_k_plus_base.py`.
- No caller passes the parameter (verified via grep); the signature now matches the abstract base in `src/gplus_trees/g_k_plus/base.py`.

## How to verify

- `./.venv/bin/pytest -q` — 470 passed, 1040 subtests passed
- `./.venv/bin/ruff check .` — clean
- `grep -rn 'with_dim_dummy\|ge_dummy' src/ tests/` — no remaining references