### PR TITLE
fix(gplus): reject negative keys reserved for dummy sentinels

### DIFF
--- a/src/gplus_trees/g_k_plus/g_k_plus_base.py
+++ b/src/gplus_trees/g_k_plus/g_k_plus_base.py
@@ -246,6 +246,11 @@ class GKPlusTreeBase(
 
         Raises:
             TypeError: If entry is not an Entry object.
+            ValueError: If the entry's key is a negative integer.  Negative
+                keys are reserved for internal dummy sentinels (key ``-dim``,
+                see :func:`get_dummy`); a negative user key would silently
+                collide with a dummy and be dropped from the real-item
+                accounting (``real_item_count`` etc.).
 
         Complexity:
             O(h · (log l + k)) amortised per dimension. When leaf sets
@@ -256,6 +261,13 @@ class GKPlusTreeBase(
         """
         if not isinstance(x_entry, Entry):
             raise TypeError(f"insert_entry(): expected Entry, got {type(x_entry).__name__}")
+        key = x_entry.item.key
+        if isinstance(key, int) and key < 0:
+            raise ValueError(
+                f"insert_entry(): key must be non-negative, got {key!r}. "
+                "Negative keys are reserved for internal dummy sentinels "
+                "(key -dim, see get_dummy) and would silently collide with a dummy."
+            )
         if self.is_empty():
             return self._insert_empty(x_entry, rank)
         return self._insert_non_empty(x_entry, rank)

--- a/src/gplus_trees/gplus_tree_base.py
+++ b/src/gplus_trees/gplus_tree_base.py
@@ -170,11 +170,22 @@ class GPlusTreeBase(AbstractSetDataStructure):
         Raises:
             TypeError: If *x* is not an ``InternalItem`` / ``LeafItem``
                 or *rank* is not a positive ``int``.
+            ValueError: If ``x.key`` is a negative integer.  Negative keys
+                are reserved for internal dummy sentinels (key ``-dim``,
+                see :func:`get_dummy`); a negative user key would silently
+                collide with a dummy and be dropped from the real-item
+                accounting (``real_item_count`` etc.).
         """
         if not isinstance(x, InternalItem | LeafItem):
             raise TypeError(f"insert(): expected InternalItem or LeafItem, got {type(x).__name__}")
         if not isinstance(rank, int) or rank <= 0:
             raise TypeError(f"insert(): rank must be a positive int, got {rank!r}")
+        if isinstance(x.key, int) and x.key < 0:
+            raise ValueError(
+                f"insert(): key must be non-negative, got {x.key!r}. "
+                "Negative keys are reserved for internal dummy sentinels "
+                "(key -dim, see get_dummy) and would silently collide with a dummy."
+            )
         insert_entry = Entry(x, x_left)
         if self.is_empty():
             return self._insert_empty(insert_entry, rank)

--- a/tests/gk_plus/test_insert.py
+++ b/tests/gk_plus/test_insert.py
@@ -519,3 +519,43 @@ class TestInternalMethodsWithEntryInsert(TestGKPlusInsert):
     #                         gnode_capacity=k,
     #                         l_factor=l_factor
     #                     )
+
+
+class TestGKPlusNegativeKeyGuard(GKPlusTreeTestCase):
+    """Verify GK+ insert paths reject negative keys reserved for dummies.
+
+    Negative keys are reserved for internal dummy items (key ``-dim``, see
+    :func:`gplus_trees.g_k_plus.g_k_plus_base.get_dummy`).  Without a guard,
+    a negative user key silently collides with a dummy: the real item is
+    swallowed and dropped from the real-item accounting
+    (``real_item_count`` reports 0, ``retrieve`` returns the ``DummyItem``).
+    Both public insert entry points must reject it — the inherited
+    ``insert`` and the GK+-specific ``insert_entry``.
+    """
+
+    def test_insert_negative_key_rejected(self):
+        # Inherited GPlusTreeBase.insert path (item + rank).
+        tree = create_gkplus_tree(K=4)
+        with self.assertRaises(ValueError):
+            tree.insert(self.make_item(-1, "v"), 1)
+
+    def test_insert_entry_negative_key_rejected(self):
+        # GK+-specific insert_entry path (Entry + rank), key -1 == dim-1 dummy.
+        tree = create_gkplus_tree(K=4)
+        with self.assertRaises(ValueError):
+            tree.insert_entry(Entry(self.make_item(-1, "v"), None), 1)
+
+    def test_insert_entry_other_negative_key_rejected(self):
+        # Any negative key is reserved (dummy key is -dim), not just -1.
+        tree = create_gkplus_tree(K=4)
+        with self.assertRaises(ValueError):
+            tree.insert_entry(Entry(self.make_item(-5, "v"), None), 2)
+
+    def test_zero_key_is_allowed(self):
+        # 0 is the smallest valid real key and must remain insertable.
+        tree = create_gkplus_tree(K=4)
+        tree.insert_entry(Entry(self.make_item(0, "v"), None), 1)
+        self.assertEqual(tree.real_item_count(), 1)
+        found, _ = tree.retrieve(0)
+        self.assertIsNotNone(found)
+        self.assertEqual(found.item.value, "v")

--- a/tests/gplus/test_gplus_tree_base.py
+++ b/tests/gplus/test_gplus_tree_base.py
@@ -385,6 +385,37 @@ class TestInsertTypeErrors(GPlusTreeTestCase):
             self.tree.insert(item, -1)
 
 
+class TestNegativeKeyGuard(GPlusTreeTestCase):
+    """Verify ``insert`` rejects negative keys reserved for dummy sentinels.
+
+    Negative keys are reserved for internal dummy items (key ``-dim``, see
+    :func:`get_dummy`).  Without a guard, inserting a negative key silently
+    collides with a dummy: the real item is swallowed and dropped from the
+    real-item accounting (``real_item_count`` reports 0, ``retrieve``
+    returns the ``DummyItem``).  See the negative-key TODO in
+    ``src/gplus_trees/base.py``.
+    """
+
+    def test_collision_is_now_rejected_key_minus_one(self):
+        # key -1 collides with the dimension-1 dummy (DUMMY_KEY == -1).
+        item = self.make_item(-1, "v")
+        with self.assertRaises(ValueError):
+            self.tree.insert(item, 1)
+
+    def test_other_negative_key_rejected(self):
+        # Any negative key is reserved (dummy key is -dim), not just -1.
+        item = self.make_item(-5, "v")
+        with self.assertRaises(ValueError):
+            self.tree.insert(item, 3)
+
+    def test_zero_key_is_allowed(self):
+        # 0 is the smallest valid real key and must remain insertable.
+        self.tree.insert(self.make_item(0, "v"), 1)
+        found, _ = self.tree.retrieve(0)
+        self.assertIsNotNone(found)
+        self.assertEqual(found.item.value, "v")
+
+
 class TestRetrieveTypeErrors(GPlusTreeTestCase):
     """Verify ``retrieve`` raises TypeError for non-int keys."""
 


### PR DESCRIPTION
## Why

The real-item accounting rests on the unenforced assumption that user keys are `>= 0` — negative keys are reserved for internal dummy sentinels (key `-dim`, see `get_dummy`). `KList.real_keys`, `get_size`/`real_item_count`, and the `tree_stats` leaf walks all treat any `key < 0` as a dummy, but no insert path validated this.

As a result, inserting a negative key silently collided with a dummy and lost data. For example `insert(key=-1)` collides with the dimension-1 dummy:

- `inserted` returns `True`, but `real_item_count()` reports `0`
- `retrieve(-1)` returns the `DummyItem`, not the inserted item — the real item (and its value) is swallowed

## What

Add a cheap guard on the two public insert entry points; both now raise `ValueError` on a negative integer key:

- `GPlusTreeBase.insert` (`src/gplus_trees/gplus_tree_base.py`) — also covers the inherited `GKPlusTreeBase.insert` path
- `GKPlusTreeBase.insert_entry` (`src/gplus_trees/g_k_plus/g_k_plus_base.py`)

The check is a single integer comparison — cheaper than the `isinstance` checks already present, negligible against insert's `O(log n · (log l + k))`. Internal dummy insertion goes through the *set-level* `KList.insert_entry`, and the only internal call to the tree-level `GKPlusTreeBase.insert_entry` (in `insert.py`) always passes real key replicas, so the guard leaves internal recursion untouched.

Regression tests were added for both insert paths (key `-1` and other negative keys) and confirm that key `0` remains insertable.

## How to verify

```
./.venv/bin/pytest -q        # 477 passed, 1040 subtests passed
./.venv/bin/ruff check .     # All checks passed!
```

Targeted:

```
./.venv/bin/pytest tests/gplus/test_gplus_tree_base.py::TestNegativeKeyGuard \
                   tests/gk_plus/test_insert.py::TestGKPlusNegativeKeyGuard -q
```
