### PR TITLE
refactor(gkplus): close the conversion cache-invalidation contract

### DIFF
--- a/src/gplus_trees/g_k_plus/conversion.py
+++ b/src/gplus_trees/g_k_plus/conversion.py
@@ -1,27 +1,38 @@
 """KList / GKPlusTree conversion logic for GK+-trees.
 
 Provides :class:`GKPlusConversionMixin`, a mixin class that adds
-``check_and_convert_set``, ``check_and_expand_klist`` and
-``check_and_collapse_tree`` to :class:`GKPlusTreeBase`.
+``convert_node_set`` and ``check_and_convert_set`` to
+:class:`GKPlusTreeBase`.
 
 Conversions are triggered when a KList exceeds ``k · l_factor`` items
 (expand) or a GKPlusTree shrinks below that threshold (collapse).
 These conversions are what create recursive dimensional nesting:
 an expanded KList becomes a GK+-tree of the next dimension.
 
+The two public entry points split by cache ownership:
+
+- ``convert_node_set(node)`` converts a set attached to a node of a
+  live tree.  The receiver must be the tree owning *node*; its cached
+  counts are invalidated internally, so callers carry no follow-up
+  contract.
+- ``check_and_convert_set(set)`` is the pure set→set function for
+  free-standing sets (split halves) that are placed into freshly
+  constructed trees, whose caches start empty.
+
 Complexity summary (n = items in set, k = KList capacity,
 threshold = k · l_factor):
 
-+-----------------------------+--------------------------------------------+
-| Operation                   | Time                                       |
-+=============================+============================================+
-| ``check_and_convert_set``   | O(1) dispatch                              |
-| ``check_and_expand_klist``  | O(n · h_{d+1}) when conversion triggers    |
-|                             | (bulk-creates a GK+-tree of dim d+1)       |
-| ``check_and_collapse_tree`` | O(threshold) early-exit counting;          |
-|                             | O(n_{d+1}) only when collapse happens      |
-|                             | (n_{d+1} ≤ threshold, so bounded by O(k))  |
-+-----------------------------+--------------------------------------------+
++------------------------------+--------------------------------------------+
+| Operation                    | Time                                       |
++==============================+============================================+
+| ``convert_node_set``         | O(1) dispatch + cache invalidation         |
+| ``check_and_convert_set``    | O(1) dispatch                              |
+| ``_check_and_expand_klist``  | O(n · h_{d+1}) when conversion triggers    |
+|                              | (bulk-creates a GK+-tree of dim d+1)       |
+| ``_check_and_collapse_tree`` | O(threshold) early-exit counting;          |
+|                              | O(n_{d+1}) only when collapse happens      |
+|                              | (n_{d+1} ≤ threshold, so bounded by O(k))  |
++------------------------------+--------------------------------------------+
 """
 
 from __future__ import annotations
@@ -33,30 +44,45 @@ from gplus_trees.g_k_plus.bulk_create import _klist_to_tree, _tree_to_klist
 from gplus_trees.klist_base import KListBase
 
 if TYPE_CHECKING:
-    from gplus_trees.g_k_plus.g_k_plus_base import GKPlusTreeBase
+    from gplus_trees.g_k_plus.g_k_plus_base import GKPlusNodeBase, GKPlusTreeBase
 
 
 class GKPlusConversionMixin:
     """Mixin that contributes KList↔GKPlusTree conversion methods to *GKPlusTreeBase*."""
 
-    def check_and_convert_set(self, set: AbstractSetDataStructure) -> AbstractSetDataStructure:
-        """Check and convert set between KList and GKPlusTree based on thresholds.
+    def convert_node_set(self, node: GKPlusNodeBase) -> None:
+        """Convert *node*'s set between KList and GKPlusTree based on thresholds.
 
-        TODO(#1): After calling this method and replacing node.set, the caller MUST
-        call _invalidate_tree_size() to ensure cached counts are invalidated.
-        Otherwise, item_count() will return stale values leading to incorrect conversions.
+        The receiver must be the tree that owns *node*: after replacing
+        ``node.set``, the receiver's cached counts (``item_cnt``, ``size``,
+        ``expanded_cnt``) are invalidated so the next ``item_count()`` /
+        ``real_item_count()`` recomputes from the converted set.  The
+        invalidation happens unconditionally — callsites reach this point
+        only after mutating the node, so the caches are stale either way.
+        """
+        node.set = self.check_and_convert_set(node.set)
+        self._invalidate_tree_size()
+
+    def check_and_convert_set(self, set: AbstractSetDataStructure) -> AbstractSetDataStructure:
+        """Check and convert a free-standing set between KList and GKPlusTree.
+
+        Pure set→set function: no tree cache is touched.  Use this for
+        split halves that are placed into freshly constructed trees
+        (whose caches start empty).  For a set attached to a node of a
+        live tree, use :meth:`convert_node_set` instead, which also
+        invalidates the owning tree's cached counts.
         """
         # Avoid circular import at module level
         from gplus_trees.g_k_plus.g_k_plus_base import GKPlusTreeBase
 
         if isinstance(set, KListBase):
-            return self.check_and_expand_klist(set)
+            return self._check_and_expand_klist(set)
         elif isinstance(set, GKPlusTreeBase):
-            return self.check_and_collapse_tree(set)
+            return self._check_and_collapse_tree(set)
         else:
             raise TypeError(f"Unsupported set type: {type(set).__name__}. Expected KListBase or GKPlusTreeBase.")
 
-    def check_and_expand_klist(self, klist: KListBase) -> AbstractSetDataStructure:
+    def _check_and_expand_klist(self, klist: KListBase) -> AbstractSetDataStructure:
         """
         Check if a KList exceeds the threshold and should be converted to a GKPlusTree.
 
@@ -65,9 +91,6 @@ class GKPlusConversionMixin:
 
         Returns:
             Either the original KList or a new GKPlusTree based on the threshold
-
-        Note (Issue #1):
-            If conversion occurs, caller must call _invalidate_tree_size() on the parent tree.
         """
         # Check if the item count exceeds l_factor * CAPACITY
         k = klist.KListNodeClass.CAPACITY
@@ -80,7 +103,7 @@ class GKPlusConversionMixin:
 
         return klist
 
-    def check_and_collapse_tree(self, tree: GKPlusTreeBase) -> AbstractSetDataStructure:
+    def _check_and_collapse_tree(self, tree: GKPlusTreeBase) -> AbstractSetDataStructure:
         """
         Check if a GKPlusTree has few enough items to be collapsed into a KList.
 
@@ -89,9 +112,6 @@ class GKPlusConversionMixin:
 
         Returns:
             Either the original tree or a new KList based on the threshold
-
-        Note (Issue #1):
-            If conversion occurs, caller must call _invalidate_tree_size() on the parent tree.
 
         Implementation note:
             An early-exit loop counts real items (key ≥ 0) and aborts as

--- a/src/gplus_trees/g_k_plus/insert.py
+++ b/src/gplus_trees/g_k_plus/insert.py
@@ -285,7 +285,6 @@ class GKPlusInsertMixin:
                     x_key,
                     replica,
                     is_leaf,
-                    check_and_convert_set,
                     capacity,
                     GKPlusTreeBase,
                 )
@@ -329,7 +328,6 @@ class GKPlusInsertMixin:
         x_key,
         replica,
         is_leaf,
-        check_and_convert_set,
         capacity,
         GKPlusTreeBase,
     ):
@@ -347,7 +345,7 @@ class GKPlusInsertMixin:
             node.set, inserted, next_entry = res[0], res[1], res[2]
             if not inserted:
                 return self.update(cur, x_entry)
-            node.set = check_and_convert_set(node.set)  # only KLists can be extended
+            cur.convert_node_set(node)  # only KLists can be extended
         else:
             digest = x_item.get_digest_for_dim(self.DIM + 1)
             new_rank = calc_rank_from_digest_k(digest, capacity)

--- a/src/gplus_trees/g_k_plus/unzip.py
+++ b/src/gplus_trees/g_k_plus/unzip.py
@@ -79,6 +79,9 @@ class GKPlusUnzipMixin:
         # below the collapse threshold.  Re-check both so that undersized
         # GKPlusTrees are converted back to KLists.  For KList splits this
         # is a no-op (a KList never needs expansion right after a split).
+        # Free-standing conversion (not convert_node_set) is safe here:
+        # self's caches were invalidated at the top of unzip, and
+        # right_set ends up in a freshly constructed tree.
         left_set = self.check_and_convert_set(left_set)
         right_set = self.check_and_convert_set(right_set)
 

--- a/src/gplus_trees/g_k_plus/zip.py
+++ b/src/gplus_trees/g_k_plus/zip.py
@@ -62,12 +62,14 @@ class GKPlusZipMixin:
                 left.node.set = bulk_create_gkplus_tree(
                     left.node.set, other.node.set.DIM, other.l_factor, type(left.node.set)
                 )
+                left._invalidate_tree_size()
             else:
                 # Convert other from KList to GKPlusTree
                 other.node.set = bulk_create_gkplus_tree(
                     other.node.set, left.node.set.DIM, left.l_factor, type(other.node.set)
                 )
                 _, _, other.node.set, _ = other.node.set.unzip(-1)
+                other._invalidate_tree_size()
 
         return left, other
 
@@ -102,8 +104,7 @@ class GKPlusZipMixin:
                 left.node = dummy_tree.node
                 left._invalidate_tree_size()
                 left, r_pivot, r_pivot_next = self.zip(left, other)
-                left.node.set = self.check_and_convert_set(left.node.set)
-                left._invalidate_tree_size()  # Correctly invalidates after conversion
+                left.convert_node_set(left.node)
 
                 return left, r_pivot, r_pivot_next
             r_pivot, r_pivot_next = other.find_pivot()
@@ -133,8 +134,7 @@ class GKPlusZipMixin:
                 )
                 other.node.set, r_pivot, r_pivot_next = singleton_tree.zip(singleton_tree, other.node.set)
 
-            other.node.set = other.check_and_convert_set(other.node.set)
-            other._invalidate_tree_size()  # Correctly invalidates after conversion
+            other.convert_node_set(other.node)
 
             # Zip r_pivot's left subtree into left
             if r_pivot and r_pivot.left_subtree:
@@ -186,17 +186,13 @@ class GKPlusZipMixin:
                 for entry in other.node.set:
                     if entry.item.key > dummy_lower_dim.key:
                         left.node.set, _, _ = left.node.set.insert_entry(entry)
-                left.node.set = left.check_and_convert_set(left.node.set)
-                # TODO(#1): Add left._invalidate_tree_size() after set conversion
-                left._invalidate_tree_size()
+                left.convert_node_set(left.node)
                 r_pivot, r_pivot_next = other.node.set.find_pivot()
 
             elif isinstance(left.node.set, GKPlusTreeBase) and isinstance(other.node.set, GKPlusTreeBase):
                 # Both are GKPlusTreeBase (after conversion) - recursively zip
                 left.node.set, r_pivot, r_pivot_next = left.node.set.zip(left.node.set, other.node.set)
-                left.node.set = self.check_and_convert_set(left.node.set)
-                # TODO(#1): Add left._invalidate_tree_size() after set conversion
-                left._invalidate_tree_size()
+                left.convert_node_set(left.node)
             else:
                 raise TypeError(
                     f"Set types should match after conversion, got {type(left.node.set).__name__} and {type(other.node.set).__name__}"

--- a/tests/gk_plus/test_set_conversion.py
+++ b/tests/gk_plus/test_set_conversion.py
@@ -695,11 +695,11 @@ class TestTreeToKList(TestSetConversion):
         self.assert_entries_present_same_instance(entries, list(new_tree))
 
 
-# ─── check_and_collapse_tree unit tests ────────────────────────────
+# ─── _check_and_collapse_tree unit tests ────────────────────────────
 
 
 class TestCheckAndCollapseTree(TestSetConversion):
-    """Direct unit tests for ``check_and_collapse_tree``.
+    """Direct unit tests for ``_check_and_collapse_tree``.
 
     The method is called indirectly during insert/unzip, but these tests
     verify the two edge cases that previously caused a
@@ -723,7 +723,7 @@ class TestCheckAndCollapseTree(TestSetConversion):
         return tree
 
     def _make_caller(self):
-        """Create a DIM-1 GKPlusTree instance to call check_and_collapse_tree on."""
+        """Create a DIM-1 GKPlusTree instance to call _check_and_collapse_tree on."""
         return create_gkplus_tree(K=self.k, dimension=1, l_factor=1.0)
 
     def test_empty_tree_collapses_to_klist(self):
@@ -731,7 +731,7 @@ class TestCheckAndCollapseTree(TestSetConversion):
         caller = self._make_caller()
         empty_tree = create_gkplus_tree(K=self.k, dimension=2, l_factor=1.0)
 
-        result = caller.check_and_collapse_tree(empty_tree)
+        result = caller._check_and_collapse_tree(empty_tree)
 
         self.assertIsInstance(result, KListBase, "Empty GKPlusTree should be collapsed to a KList")
         self.assertTrue(result.is_empty())
@@ -741,7 +741,7 @@ class TestCheckAndCollapseTree(TestSetConversion):
         caller = self._make_caller()
         dim1_tree = create_gkplus_tree(K=self.k, dimension=1, l_factor=1.0)
 
-        result = caller.check_and_collapse_tree(dim1_tree)
+        result = caller._check_and_collapse_tree(dim1_tree)
 
         self.assertIsInstance(result, GKPlusTreeBase, "DIM-1 tree should never be collapsed")
 
@@ -755,7 +755,7 @@ class TestCheckAndCollapseTree(TestSetConversion):
         self.assertIsInstance(tree, GKPlusTreeBase)
         self.assertLessEqual(tree.item_count(), threshold, "Precondition: tree must have ≤ threshold items")
 
-        result = caller.check_and_collapse_tree(tree)
+        result = caller._check_and_collapse_tree(tree)
 
         self.assertIsInstance(result, KListBase, "Small tree should be collapsed to a KList")
         # All real items should be present
@@ -772,9 +772,128 @@ class TestCheckAndCollapseTree(TestSetConversion):
         ranks = [1] * len(keys)
         tree = self._make_dim2_tree(keys, ranks)
 
-        result = caller.check_and_collapse_tree(tree)
+        result = caller._check_and_collapse_tree(tree)
 
         self.assertIsInstance(result, GKPlusTreeBase, "Large tree should remain a GKPlusTree")
+
+
+# ─── convert_node_set contract tests ───────────────────────────────
+
+
+class TestConvertNodeSet(TestSetConversion):
+    """Contract tests for ``convert_node_set``: it replaces ``node.set``
+    AND invalidates the owning tree's cached counts, so callers carry no
+    follow-up contract (previously TODO(#1) in conversion.py)."""
+
+    def setUp(self):
+        self.k = 4
+
+    def _make_leaf_tree(self, key: int = 100):
+        """DIM-1 tree with a single rank-1 leaf: node.set is a KList
+        holding the dummy and one real item."""
+        tree = create_gkplus_tree(K=self.k, dimension=1, l_factor=1.0)
+        tree, _, _ = tree.insert_entry(Entry(self.make_item(key, f"val_{key}"), None), 1)
+        return tree
+
+    def _fill_klist_to(self, tree, target_count: int):
+        """Insert entries directly into the node's KList (bypassing tree
+        insertion, so no conversion is triggered) until it holds
+        *target_count* items."""
+        key = 200
+        while tree.node.set.item_count() < target_count:
+            tree.node.set, _, _ = tree.node.set.insert_entry(Entry(self.make_item(key, f"val_{key}"), None))
+            key += 1
+        return tree
+
+    def test_expansion_invalidates_cache(self):
+        """Expansion: node.set becomes a deeper-dimension tree and the
+        cached counts are recomputed (a stale count would miss the new
+        dimension's dummy)."""
+        tree = self._make_leaf_tree()
+        threshold = int(self.k * tree.l_factor)
+        self._fill_klist_to(tree, threshold + 1)
+
+        old_count = tree.item_count()
+        self.assertEqual(tree.item_cnt, old_count, "cache should be populated before conversion")
+
+        tree.convert_node_set(tree.node)
+
+        self.assertIsInstance(tree.node.set, GKPlusTreeBase, "over-threshold KList should expand")
+        self.assertEqual(tree.node.set.DIM, 2)
+        self.assertIsNone(tree.item_cnt, "item_cnt must be invalidated by convert_node_set")
+        self.assertIsNone(tree.size, "size must be invalidated by convert_node_set")
+        self.assertIsNone(tree.expanded_cnt, "expanded_cnt must be invalidated by convert_node_set")
+        # The recomputed count sees the new dimension's dummy; a stale
+        # cache would still report old_count.
+        self.assertEqual(tree.item_count(), old_count + 1)
+
+    def test_collapse_invalidates_cache(self):
+        """Collapse: an undersized inner tree becomes a KList again and
+        the cached counts are invalidated."""
+        tree = self._make_leaf_tree()
+        tree.node.set = _klist_to_tree(tree.node.set, self.k, DIM=2, l_factor=tree.l_factor)
+        old_count = tree.item_count()
+        self.assertEqual(tree.item_cnt, old_count, "cache should be populated before conversion")
+
+        tree.convert_node_set(tree.node)
+
+        self.assertIsInstance(tree.node.set, KListBase, "undersized inner tree should collapse")
+        self.assertIsNone(tree.item_cnt, "item_cnt must be invalidated by convert_node_set")
+        self.assertEqual(tree.item_count(), tree.node.set.item_count(), "recount must match the converted set")
+
+    def test_no_op_still_invalidates(self):
+        """No conversion needed: the set stays, the caches are still
+        invalidated (callsites reach convert_node_set only after mutating
+        the node, so the caches are stale either way)."""
+        tree = self._make_leaf_tree()
+        klist = tree.node.set
+        tree.item_count()
+        self.assertIsNotNone(tree.item_cnt)
+
+        tree.convert_node_set(tree.node)
+
+        self.assertIs(tree.node.set, klist, "under-threshold KList must stay untouched")
+        self.assertIsNone(tree.item_cnt, "item_cnt must be invalidated even without conversion")
+
+
+class TestCheckConvertSameSetsInvalidation(TestSetConversion):
+    """``check_convert_same_sets`` replaces a node set outside the
+    threshold logic (type normalization before zipping); it must
+    invalidate the tree it mutated."""
+
+    def setUp(self):
+        self.k = 4
+
+    def _make_leaf_tree(self, key: int):
+        tree = create_gkplus_tree(K=self.k, dimension=1, l_factor=1.0)
+        tree, _, _ = tree.insert_entry(Entry(self.make_item(key, f"val_{key}"), None), 1)
+        return tree
+
+    def _expand_set(self, tree):
+        tree.node.set = _klist_to_tree(tree.node.set, self.k, DIM=2, l_factor=tree.l_factor)
+        return tree
+
+    def test_left_conversion_invalidates_left(self):
+        left = self._make_leaf_tree(100)
+        other = self._expand_set(self._make_leaf_tree(500))
+        left.item_count()
+        self.assertIsNotNone(left.item_cnt)
+
+        left, other = left.check_convert_same_sets(left, other)
+
+        self.assertIsInstance(left.node.set, GKPlusTreeBase)
+        self.assertIsNone(left.item_cnt, "left was mutated and must be invalidated")
+
+    def test_other_conversion_invalidates_other(self):
+        left = self._expand_set(self._make_leaf_tree(100))
+        other = self._make_leaf_tree(500)
+        other.item_count()
+        self.assertIsNotNone(other.item_cnt)
+
+        left, other = left.check_convert_same_sets(left, other)
+
+        self.assertIsInstance(other.node.set, GKPlusTreeBase)
+        self.assertIsNone(other.item_cnt, "other was mutated and must be invalidated")
 
 
 if __name__ == "__main__":

--- a/tests/test_stats_gpltree.py
+++ b/tests/test_stats_gpltree.py
@@ -518,7 +518,7 @@ class TestStatsSetThresholdsMetViolation(unittest.TestCase):
 
 class TestSetThresholdsMetRandomTreeRegression(unittest.TestCase):
     """Regression tests for ``set_thresholds_met`` invariant violations
-    that appeared when ``check_and_collapse_tree`` failed to collapse
+    that appeared when ``_check_and_collapse_tree`` failed to collapse
     undersized GKPlusTree inner sets back to KLists after unzip splits.
 
     Two root causes were identified:


### PR DESCRIPTION
## Why

`check_and_convert_set()` returned a converted set but silently required the caller to invoke `_invalidate_tree_size()` afterwards (TODO(#1)), across 13 callsites in `insert.py`, `zip.py` and `unzip.py`. A stale `item_cnt` cache after conversion misleads the next threshold check, which threatens the hysteresis-free conversion invariant (ADR-0002) that history independence depends on. The contract had already been broken once: `check_convert_same_sets()` in `zip.py` replaced `node.set` without invalidating.

## What

Split the conversion interface by cache ownership:

- `convert_node_set(node)` converts a live tree's `node.set` and invalidates the owning tree's cached counts internally — the ordering contract disappears from the interface.
- `check_and_convert_set(set)` stays a pure set-to-set function for free-standing sets (split halves) whose destination tree starts with an empty cache.

Migrated the 4 in-tree callsites in `zip.py` and 1 in `insert.py` to `convert_node_set()`, dropping the paired manual invalidation calls. `unzip.py` keeps its upfront `_invalidate_tree_size()` (part of unzip's own semantics) and continues to use `check_and_convert_set()` for the split halves. `check_convert_same_sets()` now invalidates directly after the swap.

Renamed `check_and_expand_klist`/`check_and_collapse_tree` to `_check_and_expand_klist`/`_check_and_collapse_tree` (internal now that `convert_node_set` is the node-owning entry point) and added contract tests covering expansion, collapse and the no-op case.

## How to verify

```
./.venv/bin/pytest                                     # 482 tests + 1040 subtests
./.venv/bin/pytest tests/gk_plus/test_set_conversion.py  # new contract tests
./.venv/bin/ruff check .
```