### PR TITLE
refactor(gkplus): make bulk-create internals private

### DIFF
--- a/benchmarks/benchmark_gkplus_tree.py
+++ b/benchmarks/benchmark_gkplus_tree.py
@@ -10,8 +10,8 @@ import gc
 from typing import ClassVar
 
 from benchmarks.benchmark_utils import DEFAULT_BENCHMARK_SEED, BaseBenchmark, BenchmarkUtils, stable_seed_offset
+from gplus_trees.g_k_plus.bulk_create import bulk_create_gkplus_tree
 from gplus_trees.g_k_plus.factory import make_gkplustree_classes
-from gplus_trees.g_k_plus.g_k_plus_base import bulk_create_gkplus_tree
 from gplus_trees.g_k_plus.utils import calc_ranks
 
 

--- a/benchmarks/benchmark_gkplus_tree_adversarial.py
+++ b/benchmarks/benchmark_gkplus_tree_adversarial.py
@@ -8,8 +8,8 @@ import pickle
 from typing import ClassVar
 
 from benchmarks.benchmark_utils import DEFAULT_BENCHMARK_SEED, BaseBenchmark, BenchmarkUtils, stable_seed_offset
+from gplus_trees.g_k_plus.bulk_create import bulk_create_gkplus_tree
 from gplus_trees.g_k_plus.factory import make_gkplustree_classes
-from gplus_trees.g_k_plus.g_k_plus_base import bulk_create_gkplus_tree
 from gplus_trees.g_k_plus.utils import calc_ranks
 
 

--- a/src/gplus_trees/g_k_plus/bulk_create.py
+++ b/src/gplus_trees/g_k_plus/bulk_create.py
@@ -40,11 +40,11 @@ from gplus_trees.klist_base import KListBase
 from gplus_trees.utils import calc_rank_from_digest_k
 
 # ---------------------------------------------------------------------------
-# RankData - bookkeeping for bulk tree construction
+# _RankData - bookkeeping for bulk tree construction
 # ---------------------------------------------------------------------------
 
 
-class RankData:
+class _RankData:
     """Consolidated data structure for each rank level in bulk tree creation."""
 
     __slots__ = ("boundaries", "child_indices", "entries", "next_child_idx", "pivot_item")
@@ -153,7 +153,7 @@ def _bulk_create_klist(entries: list[Entry], KListClass: type[KListBase]) -> KLi
 
 
 def _build_leaf_level_trees(
-    rank_data_map: dict[int, RankData],
+    rank_data_map: dict[int, _RankData],
     KListClass: type[KListBase],
     NodeClass,
     TreeClass,
@@ -201,7 +201,7 @@ def _build_leaf_level_trees(
 
 
 def _build_internal_levels(
-    rank_data_map: dict[int, RankData],
+    rank_data_map: dict[int, _RankData],
     leaf_trees: list,
     KListClass: type[KListBase],
     TreeClass,
@@ -358,7 +358,7 @@ def bulk_create_gkplus_tree(
     dummy = Entry(get_dummy(DIM), None)
 
     # Consolidated rank data structure
-    rank_data_map: dict[int, RankData] = {}
+    rank_data_map: dict[int, _RankData] = {}
     max_rank = 1
 
     for entry in entries:
@@ -374,7 +374,7 @@ def bulk_create_gkplus_tree(
         for rank in range(insert_rank, 0, -1):
             # Get or create rank data
             if rank not in rank_data_map:
-                rank_data_map[rank] = RankData()
+                rank_data_map[rank] = _RankData()
 
             rank_data = rank_data_map[rank]
 

--- a/src/gplus_trees/g_k_plus/g_k_plus_base.py
+++ b/src/gplus_trees/g_k_plus/g_k_plus_base.py
@@ -59,16 +59,6 @@ from gplus_trees.base import (
     Entry,
 )
 from gplus_trees.g_k_plus.base import GKTreeSetDataStructure
-
-# Re-export bulk-creation and conversion symbols for backward compatibility.
-# External code that does ``from gplus_trees.g_k_plus.g_k_plus_base import bulk_create_gkplus_tree``
-# (or _tree_to_klist, _klist_to_tree, RankData) will continue to work.
-from gplus_trees.g_k_plus.bulk_create import (  # noqa: F401
-    RankData,
-    _klist_to_tree,
-    _tree_to_klist,
-    bulk_create_gkplus_tree,
-)
 from gplus_trees.g_k_plus.conversion import GKPlusConversionMixin
 from gplus_trees.g_k_plus.insert import GKPlusInsertMixin
 from gplus_trees.g_k_plus.navigation import GKPlusNavigationMixin

--- a/tests/gk_plus/test_gk_plus_zip.py
+++ b/tests/gk_plus/test_gk_plus_zip.py
@@ -6,8 +6,9 @@ import unittest
 from dataclasses import asdict
 
 from gplus_trees.base import Entry
+from gplus_trees.g_k_plus.bulk_create import bulk_create_gkplus_tree
 from gplus_trees.g_k_plus.factory import create_gkplus_tree, make_gkplustree_classes
-from gplus_trees.g_k_plus.g_k_plus_base import GKPlusTreeBase, bulk_create_gkplus_tree
+from gplus_trees.g_k_plus.g_k_plus_base import GKPlusTreeBase
 from gplus_trees.g_k_plus.utils import calc_rank, calc_ranks
 from gplus_trees.gplus_tree_base import gtree_stats_, print_pretty
 from gplus_trees.klist_base import KListBase

--- a/tests/gk_plus/test_set_conversion.py
+++ b/tests/gk_plus/test_set_conversion.py
@@ -5,11 +5,10 @@ import random
 import unittest
 
 from gplus_trees.base import Entry
+from gplus_trees.g_k_plus.bulk_create import _klist_to_tree, _tree_to_klist
 from gplus_trees.g_k_plus.factory import create_gkplus_tree, make_gkplustree_classes
-from gplus_trees.g_k_plus.g_k_plus_base import GKPlusTreeBase, _klist_to_tree, _tree_to_klist, get_dummy
+from gplus_trees.g_k_plus.g_k_plus_base import GKPlusTreeBase, get_dummy
 from gplus_trees.g_k_plus.utils import calc_rank
-
-# from gplus_trees.g_k_plus.utils import _tree_to_klist, _klist_to_tree
 from gplus_trees.klist_base import KListBase
 from tests.gk_plus.base import TreeTestCase as GKPlusTreeTestCase
 


### PR DESCRIPTION
## Why

`bulk_create.py` defines `RankData`, a mutable bookkeeping structure that only the bulk-construction helpers themselves use. `g_k_plus_base.py` re-exported it together with `_klist_to_tree`, `_tree_to_klist` and `bulk_create_gkplus_tree` as a backward-compatibility block (with `noqa: F401`), making the bulk module's public surface wider than its purpose. Tests and callers could bind to internals through a module that merely happened to re-export them, obscuring who legitimately depends on what.

## What

- Renamed `RankData` to `_RankData` in `bulk_create.py` (all uses are module-internal; no outside references existed).
- Removed the backward-compatibility re-export block from `g_k_plus_base.py`.
- Switched the remaining importers to direct imports from `gplus_trees.g_k_plus.bulk_create`: the white-box tests `tests/gk_plus/test_set_conversion.py` and `tests/gk_plus/test_gk_plus_zip.py`, and the two bulk-construction benchmarks. In-package production callers (`conversion.py`, `zip.py`, `insert.py`) already imported directly and are unchanged.

Pure surface refactoring — no behavior change.

## How to verify

```
./.venv/bin/pytest          # 482 tests + 1040 subtests
./.venv/bin/ruff check .
grep -rn 'g_k_plus_base import.*bulk_create' src/ tests/ benchmarks/   # no hits
```