### PR TITLE
refactor(gplus): seam observers on a tree metadata interface

### DIFF
--- a/src/gplus_trees/display.py
+++ b/src/gplus_trees/display.py
@@ -26,7 +26,7 @@ def print_pretty(set: AbstractSetDataStructure | None) -> str:
       • All columns have the same width, so initial indent and
         inter-node spacing are uniform.
     """
-    from gplus_trees.gplus_tree_base import DUMMY_KEY, GPlusTreeBase, get_dummy
+    from gplus_trees.gplus_tree_base import GPlusTreeBase
     from gplus_trees.klist_base import KListBase
 
     if set is None:
@@ -52,12 +52,7 @@ def print_pretty(set: AbstractSetDataStructure | None) -> str:
         return f"({set_type}): {res_text}"
 
     tree = set
-
-    if hasattr(tree, "DIM"):
-        dim = tree.DIM if hasattr(tree, "DIM") else None
-        dum_key = get_dummy(dim).key
-    else:
-        dum_key = DUMMY_KEY
+    dum_key = tree.dummy_item.key
 
     # 1) First pass: collect each node's text and track max length
     layers_raw = collections.defaultdict(list)  # rank -> list of node-strings
@@ -67,9 +62,8 @@ def print_pretty(set: AbstractSetDataStructure | None) -> str:
         if tree.is_empty():
             return
         nonlocal max_len
-        dim = tree.DIM if hasattr(tree, "DIM") else None
-
-        p_dim = parent.DIM if parent and hasattr(parent, "DIM") else None
+        dim = tree.dimension
+        p_dim = parent.dimension if parent else None
         other_dim = False
         other_dim_processed = False
 
@@ -105,8 +99,7 @@ def print_pretty(set: AbstractSetDataStructure | None) -> str:
             layers_raw[rank].append(text)
             max_len = max(max_len, len(text))
         else:
-            dim_str = str(dim) if dim is not None else "?"
-            new_text = f"(D{dim_str}R{rank}) " + text
+            new_text = f"(D{dim}R{rank}) " + text
             layers_raw[0].append(new_text)
             max_len = max(max_len, len(new_text))
 
@@ -118,9 +111,10 @@ def print_pretty(set: AbstractSetDataStructure | None) -> str:
             if node.right_subtree:
                 collect(node.right_subtree, tree)
 
-        # Special case: if node.set is a tree of different dimension, traverse it
-        if isinstance(node.set, GPlusTreeBase) and not node.set.is_empty() and not other_dim_processed:
-            collect(node.set, tree)
+        # Special case: if node.set is an inner tree of a deeper dimension, traverse it
+        inner_set_tree = tree.inner_tree_of(node.set)
+        if inner_set_tree is not None and not inner_set_tree.is_empty() and not other_dim_processed:
+            collect(inner_set_tree, tree)
 
     collect(tree, None)
 
@@ -195,45 +189,32 @@ def print_structure(
     result = []
     node = tree.node
 
-    kwargs_print = []
-    if hasattr(node, "size"):
-        kwargs_print.append(f", size={node.size}")
-    joined_kwargs = ", ".join(kwargs_print)
-
-    result.append(f"{prefix}{node.__class__.__name__}(rank={node.rank}, set={type(node.set).__name__}{joined_kwargs})")
+    result.append(f"{prefix}{node.__class__.__name__}(rank={node.rank}, set={type(node.set).__name__})")
     result.append(node.set.print_structure(indent + 4))
 
     # Right subtree
     if node.right_subtree is not None:
         right_node = node.right_subtree.node
-        kwargs_print = []
-        if hasattr(right_node, "size"):
-            kwargs_print.append(f", size={right_node.size}")
-        joined_kwargs = ", ".join(kwargs_print)
         result.append(
             f"{prefix}    Right: {right_node.__class__.__name__}(rank={right_node.rank}, "
-            f"set={type(right_node.set).__name__}{joined_kwargs})"
+            f"set={type(right_node.set).__name__})"
         )
         result.append(right_node.set.print_structure(indent + 8))
     else:
         result.append(f"{prefix}    Right: Empty")
 
-    # Linked-list next pointer (leaf nodes only)
-    if node.rank == 1 and hasattr(node, "next") and node.next:
+    # Leaf-chain next pointer (leaf nodes only)
+    if node.rank == 1 and node.next is not None:
         if not node.next.is_empty():
             next_node = node.next.node
-            kwargs_print = []
-            if hasattr(next_node, "size"):
-                kwargs_print.append(f", size={next_node.size}")
-            joined_kwargs = ", ".join(kwargs_print)
             result.append(
                 f"{prefix}    Next: {next_node.__class__.__name__}(rank={next_node.rank}, "
-                f"set={type(next_node.set).__name__}{joined_kwargs})"
+                f"set={type(next_node.set).__name__})"
             )
             result.append(next_node.set.print_structure(indent + 8))
         else:
             result.append(f"{prefix}    Next: Empty")
-    elif node.rank == 1 and hasattr(node, "next") and node.next is None:
+    elif node.rank == 1:
         result.append(f"{prefix}    Next: Empty")
 
     return "\n".join(result)

--- a/src/gplus_trees/g_k_plus/g_k_plus_base.py
+++ b/src/gplus_trees/g_k_plus/g_k_plus_base.py
@@ -160,6 +160,27 @@ class GKPlusTreeBase(
         """Create an empty tree of the same type, forwarding *l_factor*."""
         return type(self)(l_factor=self.l_factor)
 
+    # ── Observer metadata interface (overrides GPlusTreeBase) ───────
+    @property
+    def dimension(self) -> int:
+        """The nesting depth of this tree (its ``DIM``)."""
+        return type(self).DIM
+
+    @property
+    def set_conversion_threshold(self) -> float:
+        """The node-set item count ``k · l_factor`` above which a set
+        expands into a Gᵏ⁺-tree of the next-deeper dimension.
+        """
+        return self.l_factor * self.SetClass.KListNodeClass.CAPACITY
+
+    def inner_tree_of(self, node_set: AbstractSetDataStructure) -> GKPlusTreeBase | None:
+        """Return *node_set* if it is an expanded inner tree, else ``None``."""
+        return node_set if isinstance(node_set, GKPlusTreeBase) else None
+
+    def tracked_size(self) -> int:
+        """The tree's own (cached) real-item count."""
+        return self.real_item_count()
+
     def item_count(self) -> int:
         if self.item_cnt is None:
             return self.get_tree_item_count()

--- a/src/gplus_trees/gplus_tree_base.py
+++ b/src/gplus_trees/gplus_tree_base.py
@@ -150,6 +150,56 @@ class GPlusTreeBase(AbstractSetDataStructure):
         """
         return type(self)()
 
+    # ── Observer metadata interface ────────────────────────────────────
+    # Narrow, variant-agnostic surface for the observer modules
+    # (``tree_stats``, ``display``, ``invariants``).  Observers ask these
+    # questions instead of sniffing the tree variant via
+    # ``isinstance``/``hasattr``; a new variant overrides them once
+    # instead of patching every observer.
+
+    @property
+    def dimension(self) -> int:
+        """The nesting depth of this tree.
+
+        G⁺-trees are single-dimension; multi-dimensional variants
+        override this (Gᵏ⁺-trees report their ``DIM``).
+        """
+        return 1
+
+    @property
+    def dummy_item(self) -> DummyItem:
+        """The dummy sentinel item leading this tree.
+
+        Identity-stable: every access returns the same object, so
+        observers may compare items against it with ``is``.
+        """
+        return self._get_dummy()
+
+    @property
+    def set_conversion_threshold(self) -> float | None:
+        """The node-set item count above which a set expands into an
+        inner tree, or ``None`` for variants without set conversion.
+
+        G⁺-tree node sets are always k-lists, so there is no threshold.
+        """
+        return None
+
+    def inner_tree_of(self, node_set: AbstractSetDataStructure) -> GPlusTreeBase | None:
+        """Return *node_set* as an inner (deeper-dimension) tree for
+        observers to descend into, or ``None`` when it is a plain set.
+
+        G⁺-trees never nest, so the default answers ``None``.
+        """
+        return None
+
+    def tracked_size(self) -> int | None:
+        """The number of real items this tree accounts for itself, or
+        ``None`` for variants without their own size accounting.
+
+        Observers cross-check this against independently computed stats.
+        """
+        return None
+
     # ── Public API ───────────────────────────────────────────────────
     def insert(self, x: InternalItem | LeafItem, rank: int, x_left: GPlusTreeBase | None = None) -> InsertResult:
         """Insert an item into the G+-tree (amortised O(log n)).

--- a/src/gplus_trees/invariants.py
+++ b/src/gplus_trees/invariants.py
@@ -38,10 +38,9 @@ def assert_tree_invariants_raise(
     stats: Stats,
 ) -> None:
     """Check all invariants, raising :class:`InvariantError` on the first failure."""
-    from gplus_trees.g_k_plus.g_k_plus_base import GKPlusTreeBase
-
     for flag in TREE_FLAGS:
-        if flag == "set_thresholds_met" and not isinstance(t, GKPlusTreeBase):
+        if flag == "set_thresholds_met" and t.set_conversion_threshold is None:
+            # Only variants with set conversion enforce this flag.
             continue
         if not getattr(stats, flag):
             raise InvariantError(f"Invariant failed: {flag} is False")
@@ -62,22 +61,11 @@ def assert_tree_invariants_raise(
         if stats.greatest_item is None:
             raise InvariantError("Invariant failed: greatest_item is None for non-empty tree")
 
-        if hasattr(t, "get_size"):
-            size = t.real_item_count()
-            if size != stats.real_item_count:
-                raise InvariantError(
-                    f"Invariant failed: t.real_item_count()={size} ≠ stats.real_item_count={stats.real_item_count}"
-                )
-
-
-def _get_dummy_for_tree(tree: GPlusTreeBase):
-    """Return the sentinel dummy item for *tree* (works for both G⁺ and Gᵏ⁺)."""
-    from gplus_trees.gplus_tree_base import DUMMY_ITEM, get_dummy
-
-    dim = getattr(tree.__class__, "DIM", None)
-    if dim is not None:
-        return get_dummy(dim=dim)
-    return DUMMY_ITEM
+        size = t.tracked_size()
+        if size is not None and size != stats.real_item_count:
+            raise InvariantError(
+                f"Invariant failed: t.real_item_count()={size} ≠ stats.real_item_count={stats.real_item_count}"
+            )
 
 
 def check_leaf_keys_and_values(
@@ -92,7 +80,7 @@ def check_leaf_keys_and_values(
     -------
     (keys, presence_ok, all_have_values, order_ok)
     """
-    dummy = _get_dummy_for_tree(tree)
+    dummy = tree.dummy_item
 
     keys: list[int] = []
     all_have_values = True

--- a/src/gplus_trees/tree_stats.py
+++ b/src/gplus_trees/tree_stats.py
@@ -49,9 +49,7 @@ def gtree_stats_(
     The caller can supply an existing Counter / dict for ``rank_hist``;
     otherwise a fresh Counter is used.
     """
-    # Lazy imports to break circular dependency
-    from gplus_trees.g_k_plus.g_k_plus_base import GKPlusTreeBase
-    from gplus_trees.gplus_tree_base import get_dummy
+    # Lazy import to break circular dependency
     from gplus_trees.klist_base import KListBase
 
     if rank_hist is None:
@@ -81,10 +79,13 @@ def gtree_stats_(
         )
 
     K = t.SetClass.KListNodeClass.CAPACITY
-    if hasattr(t, "l_factor"):
-        threshold = t.l_factor * K
-    else:
+    threshold = t.set_conversion_threshold
+    if threshold is None:
+        # Variant without set conversion: still flag k-lists that outgrow
+        # a single segment's capacity (diagnostic only — invariant
+        # checking skips this flag for such variants).
         threshold = K
+    dummy_key = t.dummy_item.key
 
     node = t.node
     node_set = node.set
@@ -104,8 +105,9 @@ def gtree_stats_(
     # exactly once because the inner call only processes the inner tree's
     # gnodes, not the outer tree's.
     inner_set_stats = None
-    if isinstance(node_set, GKPlusTreeBase) and not node_set.is_empty():
-        inner_set_stats = gtree_stats_(node_set, rank_hist=None, _is_root=True)
+    inner_set_tree = t.inner_tree_of(node_set)
+    if inner_set_tree is not None and not inner_set_tree.is_empty():
+        inner_set_stats = gtree_stats_(inner_set_tree, rank_hist=None, _is_root=True)
 
     # ---------- recurse on children only if rank > 1 ------------------------------------
     right_stats = gtree_stats_(node_right_subtree, rank_hist, False)
@@ -153,13 +155,11 @@ def gtree_stats_(
     for i, entry in enumerate(node_set):
         current_key = entry.item.key
 
-        # Check search tree property within the node
-        if prev_key is not None and prev_key >= current_key:
-            if hasattr(t, "DIM"):
-                if current_key >= get_dummy(t.DIM).key:
-                    stats.is_search_tree = False
-            else:
-                stats.is_search_tree = False
+        # Check search tree property within the node.  Keys below the
+        # tree's own dummy key belong to deeper-dimension dummies and are
+        # exempt from the ordering check.
+        if prev_key is not None and prev_key >= current_key and current_key >= dummy_key:
+            stats.is_search_tree = False
 
         # Process child stats if they exist (will be empty for leaf nodes)
         if i < len(child_stats):
@@ -201,17 +201,10 @@ def gtree_stats_(
                 if not cs.is_search_tree:
                     stats.is_search_tree = False
                 elif cs.least_item and prev_key and cs.least_item.key < prev_key:
-                    if hasattr(t, "DIM"):
-                        if cs.least_item.key >= get_dummy(t.DIM).key:
-                            stats.is_search_tree = False
-                    else:
+                    if cs.least_item.key >= dummy_key:
                         stats.is_search_tree = False
-                elif cs.greatest_item and cs.greatest_item.key >= current_key:
-                    if hasattr(t, "DIM"):
-                        if cs.greatest_item.key >= get_dummy(t.DIM).key:
-                            stats.is_search_tree = False
-                    else:
-                        stats.is_search_tree = False
+                elif cs.greatest_item and cs.greatest_item.key >= current_key and cs.greatest_item.key >= dummy_key:
+                    stats.is_search_tree = False
 
         prev_key = current_key
 
@@ -232,23 +225,20 @@ def gtree_stats_(
     ):
         stats.set_thresholds_met = False
 
-    if stats.is_search_tree:
-        if not right_stats.is_search_tree:
-            stats.is_search_tree = False
-        elif right_stats.least_item and prev_key is not None and right_stats.least_item.key < prev_key:
-            if hasattr(t, "DIM"):
-                if right_stats.least_item.key >= get_dummy(t.DIM).key:
-                    stats.is_search_tree = False
-            else:
-                stats.is_search_tree = False
+    if stats.is_search_tree and (
+        not right_stats.is_search_tree
+        or (
+            right_stats.least_item
+            and prev_key is not None
+            and right_stats.least_item.key < prev_key
+            and right_stats.least_item.key >= dummy_key
+        )
+    ):
+        stats.is_search_tree = False
 
     stats.is_search_tree &= right_stats.is_search_tree
-    if right_stats.least_item and right_stats.least_item.key < prev_key:
-        if hasattr(t, "DIM"):
-            if right_stats.least_item.key >= get_dummy(t.DIM).key:
-                stats.is_search_tree = False
-        else:
-            stats.is_search_tree = False
+    if right_stats.least_item and right_stats.least_item.key < prev_key and right_stats.least_item.key >= dummy_key:
+        stats.is_search_tree = False
 
     stats.internal_has_replicas &= right_stats.internal_has_replicas
     stats.internal_packed &= right_stats.internal_packed

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,137 @@
+"""Smoke tests for the display module.
+
+``display`` reads trees exclusively through the observer metadata
+interface (``dimension``, ``dummy_item``, ``inner_tree_of``), so both
+tree variants are rendered here: G⁺-trees and Gᵏ⁺-trees, including a
+Gᵏ⁺-tree with an expanded (deeper-dimension) node set.
+"""
+
+import random
+import re
+import unittest
+
+from gplus_trees.base import ItemData, LeafItem
+from gplus_trees.display import collect_leaf_keys, print_pretty, print_structure
+from gplus_trees.factory import create_gplustree
+from gplus_trees.g_k_plus.factory import create_gkplus_tree
+
+_ANSI_RE = re.compile(r"\033\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    """Strip ANSI colour codes for content assertions."""
+    return _ANSI_RE.sub("", text)
+
+
+def _make_item(key: int) -> LeafItem:
+    return LeafItem(ItemData(key, f"val_{key}"))
+
+
+def _fill(tree, keys, ranks):
+    for key, rank in zip(keys, ranks, strict=True):
+        tree.insert(_make_item(key), rank)
+    return tree
+
+
+def _fill_expanded_gk_tree():
+    """A K=2 Gᵏ⁺-tree whose root node set is an expanded dimension-2 tree.
+
+    Deterministic: fixed seed and rank cycle drive several node sets over
+    the conversion threshold (l_factor * K = 2).
+    """
+    keys = random.Random(2080).sample(range(1, 100_000), 80)
+    tree = _fill(create_gkplus_tree(K=2), keys, [1 + (i % 5) for i in range(len(keys))])
+    return tree, keys
+
+
+class TestPrintPrettyEdgeCases(unittest.TestCase):
+    def test_none_input(self):
+        self.assertEqual(print_pretty(None), "NoneType: None")
+
+    def test_invalid_type_raises(self):
+        with self.assertRaises(TypeError):
+            print_pretty("not a tree")
+
+    def test_empty_gplus_tree(self):
+        result = print_pretty(create_gplustree(K=4))
+        self.assertIn("Empty", result)
+
+    def test_empty_gkplus_tree(self):
+        result = print_pretty(create_gkplus_tree(K=4))
+        self.assertIn("Empty", result)
+
+    def test_klist(self):
+        tree = _fill(create_gplustree(K=4), [5, 6, 7], [1, 1, 1])
+        result = _plain(print_pretty(tree.node.set))
+        self.assertIn("[-1 | 5 | 6 | 7]", result)
+
+
+class TestPrintPrettyGPlusTree(unittest.TestCase):
+    def test_single_leaf(self):
+        tree = _fill(create_gplustree(K=4), [10, 20], [1, 1])
+        result = _plain(print_pretty(tree))
+        self.assertIn("Rank 1:", result)
+        # Dummy leads the leaf, keys follow in order.
+        self.assertIn("-1 | 10 | 20", result)
+
+    def test_multi_rank_tree(self):
+        tree = _fill(create_gplustree(K=4), [1, 2, 3, 4, 5, 6], [1, 2, 1, 3, 1, 2])
+        result = _plain(print_pretty(tree))
+        self.assertIn("Rank 3:", result)
+        self.assertIn("Rank 2:", result)
+        self.assertIn("Rank 1:", result)
+        for key in range(1, 7):
+            self.assertIn(str(key), result)
+        self.assertNotIn("Other Dims", result)
+
+
+class TestPrintPrettyGKPlusTree(unittest.TestCase):
+    def test_multi_rank_tree(self):
+        tree = _fill(create_gkplus_tree(K=4), [1, 2, 3, 4, 5, 6], [1, 2, 1, 3, 1, 2])
+        result = _plain(print_pretty(tree))
+        self.assertIn("Rank 3:", result)
+        self.assertIn("Rank 1:", result)
+        for key in range(1, 7):
+            self.assertIn(str(key), result)
+
+    def test_expanded_tree_renders_deeper_dimension(self):
+        tree, keys = _fill_expanded_gk_tree()
+        result = _plain(print_pretty(tree))
+        self.assertIn("Other Dims:", result)
+        self.assertIn("(D2R", result)  # inner-tree nodes labelled with dimension 2
+        self.assertIn("-2", result)  # dimension-2 dummy rendered
+        for key in keys:
+            self.assertIn(str(key), result)
+
+
+class TestPrintStructure(unittest.TestCase):
+    def test_empty_gplus_tree(self):
+        result = print_structure(create_gplustree(K=4))
+        self.assertIn("Empty", result)
+
+    def test_gplus_tree(self):
+        tree = _fill(create_gplustree(K=4), [1, 2, 3, 4], [1, 2, 1, 2])
+        result = print_structure(tree, max_depth=10)
+        self.assertIn("rank=2", result)
+        self.assertIn("rank=1", result)
+        self.assertIn("Right:", result)
+        self.assertIn("Next:", result)
+
+    def test_gkplus_tree_with_expanded_set(self):
+        tree, _ = _fill_expanded_gk_tree()
+        result = print_structure(tree, max_depth=10)
+        self.assertIn("rank=", result)
+        # The expanded root node set is a dimension-2 tree, not a k-list.
+        self.assertIn("set=GKPlusTree_K2_Dim2", result)
+        self.assertIn("Right:", result)
+
+
+class TestCollectLeafKeys(unittest.TestCase):
+    def test_gplus_tree(self):
+        keys = [3, 1, 4, 5, 9, 2, 6]
+        tree = _fill(create_gplustree(K=4), keys, [1, 2, 1, 1, 2, 1, 1])
+        self.assertEqual(collect_leaf_keys(tree), sorted(keys))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tree_metadata.py
+++ b/tests/test_tree_metadata.py
@@ -1,0 +1,215 @@
+"""Contract tests for the observer metadata interface.
+
+The observer modules (``tree_stats``, ``display``, ``invariants``) rely on
+a narrow metadata surface defined on :class:`GPlusTreeBase` and overridden
+by :class:`GKPlusTreeBase`:
+
+- ``dimension``
+- ``dummy_item``
+- ``set_conversion_threshold``
+- ``inner_tree_of``
+- ``tracked_size``
+
+Every tree variant must satisfy the same contract, so the assertions live
+in a shared mixin and run against both variants.
+"""
+
+import random
+import unittest
+
+from gplus_trees.base import DummyItem, ItemData, LeafItem
+from gplus_trees.factory import create_gplustree
+from gplus_trees.g_k_plus.factory import create_gkplus_tree, make_gkplustree_classes
+from gplus_trees.gplus_tree_base import DUMMY_ITEM, get_dummy
+from gplus_trees.klist_base import KListBase
+
+
+def _make_item(key: int) -> LeafItem:
+    return LeafItem(ItemData(key, f"val_{key}"))
+
+
+def _iter_nodes(tree):
+    """Yield every G-node of *tree* in the tree's own dimension.
+
+    Children are only visited for internal nodes (right subtree present):
+    a leaf's entries link back to shallower-dimension subtrees when the
+    leaf belongs to an inner tree, so descending there would change
+    dimension mid-traversal.
+    """
+    if tree is None or tree.is_empty():
+        return
+    node = tree.node
+    yield node
+    if node.right_subtree is not None:
+        for entry in node.set:
+            yield from _iter_nodes(entry.left_subtree)
+        yield from _iter_nodes(node.right_subtree)
+
+
+class MetadataContractMixin:
+    """Assertions every tree variant's metadata interface must satisfy.
+
+    Subclasses provide ``make_tree()`` (empty tree), ``fill_tree(tree)``
+    (returns the list of inserted keys), and the ``expected_*`` values.
+    """
+
+    expected_dimension: int
+    expected_threshold: float | None
+    tracks_size: bool
+
+    def make_tree(self):
+        raise NotImplementedError
+
+    def fill_tree(self, tree) -> list[int]:
+        raise NotImplementedError
+
+    # -- dimension ----------------------------------------------------
+    def test_dimension_is_positive_int(self):
+        tree = self.make_tree()
+        self.assertIsInstance(tree.dimension, int)
+        self.assertGreaterEqual(tree.dimension, 1)
+
+    def test_dimension_matches_expected(self):
+        self.assertEqual(self.make_tree().dimension, self.expected_dimension)
+
+    # -- dummy_item ---------------------------------------------------
+    def test_dummy_item_is_dummy_with_negative_dimension_key(self):
+        tree = self.make_tree()
+        self.assertIsInstance(tree.dummy_item, DummyItem)
+        self.assertEqual(tree.dummy_item.key, -tree.dimension)
+
+    def test_dummy_item_is_identity_stable(self):
+        tree = self.make_tree()
+        self.assertIs(tree.dummy_item, tree.dummy_item)
+        self.assertIs(tree.dummy_item, self.make_tree().dummy_item)
+
+    def test_leaf_items_include_dummy_key(self):
+        """The filled tree's leaves contain the tree's own dummy key."""
+        tree = self.make_tree()
+        self.fill_tree(tree)
+        leaf_keys = [entry.item.key for leaf in tree.iter_leaf_nodes() for entry in leaf.set]
+        self.assertIn(tree.dummy_item.key, leaf_keys)
+
+    # -- set_conversion_threshold --------------------------------------
+    def test_set_conversion_threshold_matches_expected(self):
+        self.assertEqual(self.make_tree().set_conversion_threshold, self.expected_threshold)
+
+    # -- inner_tree_of --------------------------------------------------
+    def test_inner_tree_of_klist_is_none(self):
+        tree = self.make_tree()
+        self.assertIsNone(tree.inner_tree_of(tree.SetClass()))
+
+    def test_inner_tree_of_node_sets_is_none_or_deeper_tree(self):
+        tree = self.make_tree()
+        self.fill_tree(tree)
+
+        def check(subject):
+            for node in _iter_nodes(subject):
+                inner = subject.inner_tree_of(node.set)
+                if isinstance(node.set, KListBase):
+                    self.assertIsNone(inner)
+                else:
+                    self.assertIs(inner, node.set)
+                    self.assertEqual(inner.dimension, subject.dimension + 1)
+                    check(inner)
+
+        check(tree)
+
+    # -- tracked_size ----------------------------------------------------
+    def test_tracked_size_of_filled_tree(self):
+        tree = self.make_tree()
+        keys = self.fill_tree(tree)
+        size = tree.tracked_size()
+        if self.tracks_size:
+            self.assertEqual(size, len(keys))
+        else:
+            self.assertIsNone(size)
+
+
+class TestGPlusTreeMetadataContract(MetadataContractMixin, unittest.TestCase):
+    """G⁺-trees: single-dimension, no set conversion, no size accounting."""
+
+    expected_dimension = 1
+    expected_threshold = None
+    tracks_size = False
+
+    def make_tree(self):
+        return create_gplustree(K=4)
+
+    def fill_tree(self, tree) -> list[int]:
+        keys = list(range(1, 41))
+        for i, key in enumerate(keys):
+            tree.insert(_make_item(key), rank=(i % 3) + 1)
+        return keys
+
+    def test_dummy_item_is_the_shared_sentinel(self):
+        self.assertIs(self.make_tree().dummy_item, DUMMY_ITEM)
+
+    def test_leaves_contain_dummy_item_identically(self):
+        """G⁺-trees store the exact ``dummy_item`` object in their leaves,
+        which is what ``invariants.check_leaf_keys_and_values`` relies on."""
+        tree = self.make_tree()
+        self.fill_tree(tree)
+        leaf_items = [entry.item for leaf in tree.iter_leaf_nodes() for entry in leaf.set]
+        self.assertTrue(
+            any(item is tree.dummy_item for item in leaf_items),
+            "tree.dummy_item must appear (by identity) among the leaf items",
+        )
+
+
+class TestGKPlusTreeMetadataContract(MetadataContractMixin, unittest.TestCase):
+    """Gᵏ⁺-trees: dimensioned, converting node sets, tracking their size."""
+
+    K = 2
+    L_FACTOR = 1.0
+    expected_dimension = 1
+    expected_threshold = 2.0  # l_factor * K
+    tracks_size = True
+
+    def make_tree(self):
+        return create_gkplus_tree(K=self.K, l_factor=self.L_FACTOR)
+
+    def fill_tree(self, tree) -> list[int]:
+        # Deterministic fill (fixed seed / rank cycle) that drives several
+        # node sets over the conversion threshold (l_factor * K = 2), so
+        # the tree contains expanded, deeper-dimension inner sets.
+        keys = random.Random(2080).sample(range(1, 100_000), 80)
+        for i, key in enumerate(keys):
+            tree.insert(_make_item(key), rank=1 + (i % 5))
+        return keys
+
+    def test_dummy_item_is_the_dimension_sentinel(self):
+        self.assertIs(self.make_tree().dummy_item, get_dummy(dim=1))
+
+    def test_filled_tree_has_an_expanded_inner_set(self):
+        """The fill must actually exercise the inner-tree branch of the contract."""
+        tree = self.make_tree()
+        self.fill_tree(tree)
+        inner_trees = [
+            tree.inner_tree_of(node.set) for node in _iter_nodes(tree) if not isinstance(node.set, KListBase)
+        ]
+        self.assertTrue(inner_trees, "expected at least one expanded node set")
+
+    def test_threshold_scales_with_l_factor(self):
+        tree = create_gkplus_tree(K=4, l_factor=1.5)
+        self.assertEqual(tree.set_conversion_threshold, 6.0)
+
+
+class TestGKPlusTreeDeeperDimensionMetadata(unittest.TestCase):
+    """A dimension-3 Gᵏ⁺-tree class reports its own dimension and dummy."""
+
+    def make_tree(self):
+        GKPlusTreeK, _, _, _ = make_gkplustree_classes(K=4, dimension=3)
+        return GKPlusTreeK()
+
+    def test_dimension(self):
+        self.assertEqual(self.make_tree().dimension, 3)
+
+    def test_dummy_item(self):
+        tree = self.make_tree()
+        self.assertIs(tree.dummy_item, get_dummy(dim=3))
+        self.assertEqual(tree.dummy_item.key, -3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,5 @@
 """Utility functions for testing GPlusTree invariants."""
 
-from gplus_trees.g_k_plus.g_k_plus_base import GKPlusTreeBase
 from gplus_trees.gplus_tree_base import (
     GPlusTreeBase,
     Stats,
@@ -24,8 +23,8 @@ def assert_tree_invariants_tc(
     for flag in TREE_FLAGS:
         if flag in exclude_checks:
             continue
-        if flag == "set_thresholds_met" and not isinstance(t, GKPlusTreeBase):
-            # this flag is only relevant for GKPlusTreeBase
+        if flag == "set_thresholds_met" and t.set_conversion_threshold is None:
+            # this flag is only relevant for variants with set conversion
             continue
         tc.assertTrue(getattr(stats, flag), f"Invariant failed: {flag} is False\n\n{err_msg}")
 
@@ -54,11 +53,11 @@ def assert_tree_invariants_tc(
             stats.greatest_item, f"Invariant failed: greatest_item is None for non-empty tree\n\n{err_msg}"
         )
 
-        # if t has a method get_size, the result must be equal to stats.real_item_count
-        if hasattr(t, "get_size") and not t.is_empty():
-            size = t.get_size()
+        # if t tracks its own size, it must equal stats.real_item_count
+        size = t.tracked_size()
+        if size is not None:
             tc.assertEqual(
                 size,
                 stats.real_item_count,
-                f"Invariant failed: get_size()={size} ≠ real_item_count={stats.real_item_count}, \n\n{err_msg}",
+                f"Invariant failed: tracked_size()={size} ≠ real_item_count={stats.real_item_count}, \n\n{err_msg}",
             )


### PR DESCRIPTION
## Why

Three observer modules probed the tree variant by feature-sniffing: `tree_stats.py` branched on `hasattr(t, "l_factor")`/`hasattr(t, "DIM")` and `isinstance(node_set, GKPlusTreeBase)`, `display.py` on `hasattr(tree, "DIM")` and `hasattr(node, "size"/"next")`, and `invariants.py` on `isinstance(t, GKPlusTreeBase)`/`hasattr(t, "get_size")`/`getattr(cls, "DIM")`. The trees' interface towards observers was effectively "whatever attributes happen to exist" — any new tree variant would have to patch all three modules, and the sniffing hid which questions observers actually need answered.

## What

- Add a narrow observer metadata interface on `GPlusTreeBase` with Gᵏ⁺ overrides on `GKPlusTreeBase`:
  - `dimension` — nesting depth (G⁺: 1, Gᵏ⁺: `DIM`)
  - `dummy_item` — the tree's dummy sentinel (delegates to the existing `_get_dummy()` hook, so identities are unchanged)
  - `set_conversion_threshold` — `k · l_factor`, or `None` for variants without set conversion
  - `inner_tree_of(node_set)` — the expanded deeper-dimension tree to descend into, or `None`
  - `tracked_size()` — the variant's own real-item accounting, or `None`
- Migrate `tree_stats.py`, `display.py` and `invariants.py` (plus the mirroring test helper `tests/utils.py`) to that interface. Variant sniffing disappears from the observers; `isinstance(..., KListBase)` checks that only distinguish the container type remain.
- Remove dead probing in `print_structure`: no node class defines `size` (tree-level size lives on `GKPlusTreeBase`), and every tree node initialises `next`, so the `hasattr` guards never changed the output.
- Tests: a contract mixin runs the same metadata assertions against both variants (including inner-tree descent across dimensions and a dimension-3 class); the previously untested `display.py` gets smoke tests for both variants, including a Gᵏ⁺-tree with expanded deeper-dimension node sets.

Observer behavior is unchanged: stats, invariant checking and rendered output are byte-identical to `main` for G⁺- and Gᵏ⁺-trees (verified with a fixture dump of `gtree_stats_`, `print_pretty`, `print_structure`, `collect_leaf_keys` and `assert_tree_invariants_raise` over both variants, including expanded inner sets and empty/edge cases, diffed against `main`).

Noted while testing, left as is: `get_dummy` is `functools.cache`d, and positional (`get_dummy(1)`, insert paths) vs. keyword (`get_dummy(dim=1)`, `_get_dummy`) calls cache separately, so two sentinel objects per dimension circulate in Gᵏ⁺-trees. `dummy_item` reproduces the keyword object that `invariants` already compared against, keeping behavior identical; the leaf-identity contract test is therefore scoped to G⁺-trees.

## How to verify

```
./.venv/bin/pytest                            # 520 tests + 1040 subtests
./.venv/bin/pytest tests/test_tree_metadata.py tests/test_display.py
./.venv/bin/ruff check . && ./.venv/bin/ruff format .
```

Grep check: `grep -n "hasattr\|isinstance" src/gplus_trees/{tree_stats,display,invariants}.py` — remaining hits only distinguish k-list vs. tree containers or validate input types.
