### PR TITLE
refactor(gkplus): deepen the growth path behind insert_entry()

### DIFF
--- a/benchmarks/benchmark_gkplus_tree.py
+++ b/benchmarks/benchmark_gkplus_tree.py
@@ -10,7 +10,6 @@ import gc
 from typing import ClassVar
 
 from benchmarks.benchmark_utils import DEFAULT_BENCHMARK_SEED, BaseBenchmark, BenchmarkUtils, stable_seed_offset
-from gplus_trees.g_k_plus.bulk_create import bulk_create_gkplus_tree
 from gplus_trees.g_k_plus.factory import make_gkplustree_classes
 from gplus_trees.g_k_plus.utils import calc_ranks
 
@@ -96,7 +95,7 @@ class GKPlusTreeRetrieveBenchmarks(BaseBenchmark):
         # Check if we have a cached tree and its data for these parameters
         if tree_cache_key not in self._tree_cache:
             # Create and populate GKPlusTree (only when not cached)
-            _, _, klist_class, _ = make_gkplustree_classes(capacity)
+            tree_class, _, _, _ = make_gkplustree_classes(capacity)
 
             # Generate and insert test data with deterministic seed
             seed_offset = stable_seed_offset(capacity, size, distribution, l_factor)
@@ -107,8 +106,13 @@ class GKPlusTreeRetrieveBenchmarks(BaseBenchmark):
 
             entries = BenchmarkUtils.create_test_entries(insert_keys)
 
-            # Use bulk_create_gkplus_tree for efficient initial tree construction
-            tree = bulk_create_gkplus_tree(entries, DIM=1, l_factor=l_factor, KListClass=klist_class)
+            # Build the tree through the public insert interface.  GK+-trees
+            # are canonical, so this yields the same structure as a bulk
+            # build; construction happens once per cache key (setup only).
+            ranks = calc_ranks(insert_keys, capacity)
+            tree = tree_class(l_factor=l_factor)
+            for entry, rank in zip(entries, ranks, strict=True):
+                tree, _, _ = tree.insert_entry(entry, rank)
 
             # Cache the tree and associated data together
             self._tree_cache[tree_cache_key] = (tree, insert_keys)

--- a/benchmarks/benchmark_gkplus_tree_adversarial.py
+++ b/benchmarks/benchmark_gkplus_tree_adversarial.py
@@ -8,8 +8,7 @@ import pickle
 from typing import ClassVar
 
 from benchmarks.benchmark_utils import DEFAULT_BENCHMARK_SEED, BaseBenchmark, BenchmarkUtils, stable_seed_offset
-from gplus_trees.g_k_plus.bulk_create import bulk_create_gkplus_tree
-from gplus_trees.g_k_plus.factory import make_gkplustree_classes
+from gplus_trees.g_k_plus.factory import create_gkplus_tree, make_gkplustree_classes
 from gplus_trees.g_k_plus.utils import calc_ranks
 
 
@@ -114,8 +113,14 @@ class GKPlusTreeAdversarialRetrieveBenchmarks(BaseBenchmark):
         if tree_cache_key not in self._tree_cache:
             insert_keys = load_adversarial_keys_from_file(key_count=size, capacity=capacity, dim_limit=dim_limit)
             entries = BenchmarkUtils.create_test_entries(insert_keys)
-            _, _, klist_class, _ = make_gkplustree_classes(capacity)
-            tree = bulk_create_gkplus_tree(entries, dim_limit, l_factor, klist_class)
+            # Build the dim_limit-dimension tree through the public insert
+            # interface.  GK+-trees are canonical, so this yields the same
+            # structure as a bulk build; construction happens once per
+            # cache key (setup only).
+            tree = create_gkplus_tree(capacity, dim_limit, l_factor)
+            ranks = calc_ranks(insert_keys, capacity, DIM=dim_limit)
+            for entry, rank in zip(entries, ranks, strict=True):
+                tree, _, _ = tree.insert_entry(entry, rank)
             self._tree_cache[tree_cache_key] = (tree, insert_keys)
         self.tree, self.insert_keys = self._tree_cache[tree_cache_key]
 

--- a/src/gplus_trees/g_k_plus/bulk_create.py
+++ b/src/gplus_trees/g_k_plus/bulk_create.py
@@ -1,19 +1,27 @@
 """Bulk creation and conversion utilities for GK+-trees.
 
+Everything in this module is internal to the ``g_k_plus`` package: the
+growth path (insert → conversion → bulk build of the deeper dimension)
+is reachable from outside only through ``GKPlusTreeBase.insert_entry``.
+Code outside the package must not import from here; trees are built
+through the factory (``create_gkplus_tree`` / ``make_gkplustree_classes``)
+plus ``insert_entry`` — GK+-trees are canonical, so an insert-built tree
+is structurally identical to a bulk-built one.
+
 Provides:
-- ``bulk_create_gkplus_tree`` - bottom-up bulk creation from an entry sequence.
+- ``_bulk_create_gkplus_tree`` - bottom-up bulk creation from an entry sequence.
 - ``_tree_to_klist`` / ``_klist_to_tree`` - bidirectional conversions.
 - ``_bulk_create_klist`` - helper to populate a KList from entries.
 
 Internal helpers ``_build_leaf_level_trees`` and ``_build_internal_levels``
-are used by ``bulk_create_gkplus_tree`` and are not part of the public API.
+are used by ``_bulk_create_gkplus_tree`` only.
 
 Complexity summary (n = entries, k = KList capacity, h = resulting height):
 
 +-------------------------------+------------------------------------------+
 | Operation                     | Time                                     |
 +===============================+==========================================+
-| ``bulk_create_gkplus_tree``   | O(n · h) amortised; leaf sets that       |
+| ``_bulk_create_gkplus_tree``  | O(n · h) amortised; leaf sets that       |
 |                               | exceed the threshold are recursively     |
 |                               | bulk-created at dimension d+1.           |
 | ``_tree_to_klist``            | O(n_{d+1}) at dimension d+1; iterates    |
@@ -135,7 +143,7 @@ def _klist_to_tree(klist: KListBase, K: int, DIM: int, l_factor: float = 1.0):
 
     if klist.is_empty():
         return _get_create_gkplus_tree()(K, DIM, l_factor)
-    return bulk_create_gkplus_tree(klist, DIM, l_factor, type(klist))
+    return _bulk_create_gkplus_tree(klist, DIM, l_factor, type(klist))
 
 
 # ---------------------------------------------------------------------------
@@ -188,7 +196,7 @@ def _build_leaf_level_trees(
         if len(node_entries) <= threshold:
             node_set = _bulk_create_klist(node_entries, KListClass)
         else:
-            node_set = bulk_create_gkplus_tree(node_entries, TreeClass.DIM + 1, l_factor, KListClass)
+            node_set = _bulk_create_gkplus_tree(node_entries, TreeClass.DIM + 1, l_factor, KListClass)
         leaf_node = NodeClass(1, node_set, None)
         leaf_tree = TreeClass(l_factor=l_factor)
         leaf_tree.node = leaf_node
@@ -230,7 +238,7 @@ def _build_internal_levels(
 
     # Cache frequently accessed functions and values for better performance
     bulk_create_klist_fn = _bulk_create_klist
-    bulk_create_gkplus_tree_fn = bulk_create_gkplus_tree
+    bulk_create_gkplus_tree_fn = _bulk_create_gkplus_tree
     tree_dim_plus_one = TreeClass.DIM + 1
 
     rank = 2
@@ -320,7 +328,7 @@ def _build_internal_levels(
 # ---------------------------------------------------------------------------
 
 
-def bulk_create_gkplus_tree(
+def _bulk_create_gkplus_tree(
     entries: list[Entry] | KListBase,
     DIM: int,
     l_factor: float,

--- a/src/gplus_trees/g_k_plus/conversion.py
+++ b/src/gplus_trees/g_k_plus/conversion.py
@@ -1,7 +1,7 @@
 """KList / GKPlusTree conversion logic for GK+-trees.
 
 Provides :class:`GKPlusConversionMixin`, a mixin class that adds
-``convert_node_set`` and ``check_and_convert_set`` to
+``_convert_node_set`` and ``_check_and_convert_set`` to
 :class:`GKPlusTreeBase`.
 
 Conversions are triggered when a KList exceeds ``k · l_factor`` items
@@ -9,13 +9,18 @@ Conversions are triggered when a KList exceeds ``k · l_factor`` items
 These conversions are what create recursive dimensional nesting:
 an expanded KList becomes a GK+-tree of the next dimension.
 
-The two public entry points split by cache ownership:
+Everything here is an internal seam of the growth path: callers outside
+the ``g_k_plus`` package reach conversions only implicitly, through
+``GKPlusTreeBase.insert_entry`` (and the other tree-level operations
+``unzip`` / ``zip``).
 
-- ``convert_node_set(node)`` converts a set attached to a node of a
+The two package-internal entry points split by cache ownership:
+
+- ``_convert_node_set(node)`` converts a set attached to a node of a
   live tree.  The receiver must be the tree owning *node*; its cached
   counts are invalidated internally, so callers carry no follow-up
   contract.
-- ``check_and_convert_set(set)`` is the pure set→set function for
+- ``_check_and_convert_set(set)`` is the pure set→set function for
   free-standing sets (split halves) that are placed into freshly
   constructed trees, whose caches start empty.
 
@@ -25,8 +30,8 @@ threshold = k · l_factor):
 +------------------------------+--------------------------------------------+
 | Operation                    | Time                                       |
 +==============================+============================================+
-| ``convert_node_set``         | O(1) dispatch + cache invalidation         |
-| ``check_and_convert_set``    | O(1) dispatch                              |
+| ``_convert_node_set``        | O(1) dispatch + cache invalidation         |
+| ``_check_and_convert_set``   | O(1) dispatch                              |
 | ``_check_and_expand_klist``  | O(n · h_{d+1}) when conversion triggers    |
 |                              | (bulk-creates a GK+-tree of dim d+1)       |
 | ``_check_and_collapse_tree`` | O(threshold) early-exit counting;          |
@@ -50,7 +55,7 @@ if TYPE_CHECKING:
 class GKPlusConversionMixin:
     """Mixin that contributes KList↔GKPlusTree conversion methods to *GKPlusTreeBase*."""
 
-    def convert_node_set(self, node: GKPlusNodeBase) -> None:
+    def _convert_node_set(self, node: GKPlusNodeBase) -> None:
         """Convert *node*'s set between KList and GKPlusTree based on thresholds.
 
         The receiver must be the tree that owns *node*: after replacing
@@ -60,16 +65,16 @@ class GKPlusConversionMixin:
         invalidation happens unconditionally — callsites reach this point
         only after mutating the node, so the caches are stale either way.
         """
-        node.set = self.check_and_convert_set(node.set)
+        node.set = self._check_and_convert_set(node.set)
         self._invalidate_tree_size()
 
-    def check_and_convert_set(self, set: AbstractSetDataStructure) -> AbstractSetDataStructure:
+    def _check_and_convert_set(self, set: AbstractSetDataStructure) -> AbstractSetDataStructure:
         """Check and convert a free-standing set between KList and GKPlusTree.
 
         Pure set→set function: no tree cache is touched.  Use this for
         split halves that are placed into freshly constructed trees
         (whose caches start empty).  For a set attached to a node of a
-        live tree, use :meth:`convert_node_set` instead, which also
+        live tree, use :meth:`_convert_node_set` instead, which also
         invalidates the owning tree's cached counts.
         """
         # Avoid circular import at module level

--- a/src/gplus_trees/g_k_plus/g_k_plus_base.py
+++ b/src/gplus_trees/g_k_plus/g_k_plus_base.py
@@ -239,7 +239,7 @@ class GKPlusTreeBase(
 
         Complexity:
             O(h · (log l + k)) amortised per dimension. When leaf sets
-            are inner GK+-trees (expanded via ``check_and_convert_set``),
+            are inner GK+-trees (expanded via ``_check_and_convert_set``),
             set-level operations (insert, split) recurse into dimension
             d+1.  Total worst-case across D dimensions:
             O(h_1 · h_2 · … · h_D · (log l + k)).

--- a/src/gplus_trees/g_k_plus/insert.py
+++ b/src/gplus_trees/g_k_plus/insert.py
@@ -36,7 +36,7 @@ from gplus_trees.base import (
     Entry,
     _get_replica,
 )
-from gplus_trees.g_k_plus.bulk_create import bulk_create_gkplus_tree
+from gplus_trees.g_k_plus.bulk_create import _bulk_create_gkplus_tree
 from gplus_trees.gplus_tree_base import get_dummy
 from gplus_trees.klist_base import KListBase
 from gplus_trees.utils import calc_rank_from_digest_k
@@ -260,7 +260,7 @@ class GKPlusInsertMixin:
         replica = _get_replica(x_item)
         TreeClass = type(self)
         NodeClass = self.NodeClass
-        check_and_convert_set = self.check_and_convert_set
+        check_and_convert_set = self._check_and_convert_set
         l_factor = self.l_factor
         capacity = self.KListClass.KListNodeClass.CAPACITY
 
@@ -345,7 +345,7 @@ class GKPlusInsertMixin:
             node.set, inserted, next_entry = res[0], res[1], res[2]
             if not inserted:
                 return self.update(cur, x_entry)
-            cur.convert_node_set(node)  # only KLists can be extended
+            cur._convert_node_set(node)  # only KLists can be extended
         else:
             digest = x_item.get_digest_for_dim(self.DIM + 1)
             new_rank = calc_rank_from_digest_k(digest, capacity)
@@ -423,7 +423,7 @@ class GKPlusInsertMixin:
             if isinstance(right_split, GKPlusTreeBase):
                 digest = x_item.get_digest_for_dim(self.DIM + 1)
                 calc_rank_from_digest_k(digest, capacity)
-                tree_insert = bulk_create_gkplus_tree(
+                tree_insert = _bulk_create_gkplus_tree(
                     [insert_entry], self.DIM + 1, l_factor=self.l_factor, KListClass=self.SetClass
                 )
 

--- a/src/gplus_trees/g_k_plus/unzip.py
+++ b/src/gplus_trees/g_k_plus/unzip.py
@@ -19,7 +19,7 @@ k = KList capacity, l = KList nodes):
 
 When node sets are inner GK+-trees, the ``split_inplace`` / ``unzip``
 call on ``node.set`` recurses into dimension d+1. The
-``check_and_convert_set`` calls after splitting use early-exit
+``_check_and_convert_set`` calls after splitting use early-exit
 counting (O(k) per call) and only trigger collapse when the split
 half is small enough (≤ threshold items).
 """
@@ -79,11 +79,11 @@ class GKPlusUnzipMixin:
         # below the collapse threshold.  Re-check both so that undersized
         # GKPlusTrees are converted back to KLists.  For KList splits this
         # is a no-op (a KList never needs expansion right after a split).
-        # Free-standing conversion (not convert_node_set) is safe here:
+        # Free-standing conversion (not _convert_node_set) is safe here:
         # self's caches were invalidated at the top of unzip, and
         # right_set ends up in a freshly constructed tree.
-        left_set = self.check_and_convert_set(left_set)
-        right_set = self.check_and_convert_set(right_set)
+        left_set = self._check_and_convert_set(left_set)
+        right_set = self._check_and_convert_set(right_set)
 
         # Update the current node's set
         node.set = left_set

--- a/src/gplus_trees/g_k_plus/zip.py
+++ b/src/gplus_trees/g_k_plus/zip.py
@@ -29,7 +29,7 @@ from gplus_trees.base import (
     Entry,
     _get_replica,
 )
-from gplus_trees.g_k_plus.bulk_create import bulk_create_gkplus_tree
+from gplus_trees.g_k_plus.bulk_create import _bulk_create_gkplus_tree
 from gplus_trees.gplus_tree_base import get_dummy
 from gplus_trees.klist_base import KListBase
 
@@ -55,17 +55,24 @@ class GKPlusZipMixin:
         l_set_is_klist = isinstance(left.node.set, KListBase)
         o_set_is_klist = isinstance(other.node.set, KListBase)
 
-        # Convert to same type if needed
+        # Convert to same type if needed.
+        #
+        # This is deliberately NOT the conversion seam
+        # (``_check_and_convert_set``): that seam is threshold-gated and
+        # would leave a KList at or below ``k · l_factor`` items
+        # unconverted — precisely the common case here, where one set
+        # already expanded and its (small) sibling must be lifted to the
+        # same type unconditionally so the sets can be merged.
         if l_set_is_klist != o_set_is_klist:
             if l_set_is_klist:
                 # Convert left from KList to GKPlusTree
-                left.node.set = bulk_create_gkplus_tree(
+                left.node.set = _bulk_create_gkplus_tree(
                     left.node.set, other.node.set.DIM, other.l_factor, type(left.node.set)
                 )
                 left._invalidate_tree_size()
             else:
                 # Convert other from KList to GKPlusTree
-                other.node.set = bulk_create_gkplus_tree(
+                other.node.set = _bulk_create_gkplus_tree(
                     other.node.set, left.node.set.DIM, left.l_factor, type(other.node.set)
                 )
                 _, _, other.node.set, _ = other.node.set.unzip(-1)
@@ -104,7 +111,7 @@ class GKPlusZipMixin:
                 left.node = dummy_tree.node
                 left._invalidate_tree_size()
                 left, r_pivot, r_pivot_next = self.zip(left, other)
-                left.convert_node_set(left.node)
+                left._convert_node_set(left.node)
 
                 return left, r_pivot, r_pivot_next
             r_pivot, r_pivot_next = other.find_pivot()
@@ -129,12 +136,12 @@ class GKPlusZipMixin:
                 r_pivot, r_pivot_next = other.node.set.find_pivot()
                 other.node.set, _, _ = other.node.set.insert_entry(replica_entry, other.node.rank)
             else:
-                singleton_tree = bulk_create_gkplus_tree(
+                singleton_tree = _bulk_create_gkplus_tree(
                     [replica_entry], left.DIM + 1, l_factor=left.l_factor, KListClass=left.SetClass
                 )
                 other.node.set, r_pivot, r_pivot_next = singleton_tree.zip(singleton_tree, other.node.set)
 
-            other.convert_node_set(other.node)
+            other._convert_node_set(other.node)
 
             # Zip r_pivot's left subtree into left
             if r_pivot and r_pivot.left_subtree:
@@ -186,13 +193,13 @@ class GKPlusZipMixin:
                 for entry in other.node.set:
                     if entry.item.key > dummy_lower_dim.key:
                         left.node.set, _, _ = left.node.set.insert_entry(entry)
-                left.convert_node_set(left.node)
+                left._convert_node_set(left.node)
                 r_pivot, r_pivot_next = other.node.set.find_pivot()
 
             elif isinstance(left.node.set, GKPlusTreeBase) and isinstance(other.node.set, GKPlusTreeBase):
                 # Both are GKPlusTreeBase (after conversion) - recursively zip
                 left.node.set, r_pivot, r_pivot_next = left.node.set.zip(left.node.set, other.node.set)
-                left.convert_node_set(left.node)
+                left._convert_node_set(left.node)
             else:
                 raise TypeError(
                     f"Set types should match after conversion, got {type(left.node.set).__name__} and {type(other.node.set).__name__}"

--- a/tests/gk_plus/test_gk_plus_zip.py
+++ b/tests/gk_plus/test_gk_plus_zip.py
@@ -5,9 +5,7 @@ import random
 import unittest
 from dataclasses import asdict
 
-from gplus_trees.base import Entry
-from gplus_trees.g_k_plus.bulk_create import bulk_create_gkplus_tree
-from gplus_trees.g_k_plus.factory import create_gkplus_tree, make_gkplustree_classes
+from gplus_trees.g_k_plus.factory import create_gkplus_tree
 from gplus_trees.g_k_plus.g_k_plus_base import GKPlusTreeBase
 from gplus_trees.g_k_plus.utils import calc_rank, calc_ranks
 from gplus_trees.gplus_tree_base import gtree_stats_, print_pretty
@@ -45,29 +43,24 @@ class TestGKPlusTreeZip(TreeTestCase):
         return tree
 
     def _create_tree_via_unzip(self, keys: list[int], ranks: list[int], tree=None, k=4):
-        """Helper to create a tree by first building normally, then unzipping at key -1."""
-        #     if tree is None:
-        #         tree = create_gkplus_tree(K=k, dimension=1)
+        """Helper to create a tree by first building normally, then unzipping at key -1.
 
-        #     # First build the tree normally
-        #     for key, rank in zip(keys, ranks):
-        #         item = self.make_item(key, f"val_{key}")
-        #         tree, inserted, _ = tree.insert(item, rank=rank)
-        #         self.assertTrue(inserted, f"Failed to insert item with key {key}")
-
-        # Bulk create version
-        # Efficiently sort keys and ranks by key, keeping ranks aligned
-        entries = [Entry(self.make_item(key, f"val_{key}"), None) for key in keys]
+        The *ranks* argument is ignored: the tree is built through the
+        public insert interface at the target dimension, using the keys'
+        natural (digest-derived) ranks — the same ranks a bulk build
+        would compute internally.
+        """
         dimension = 1 if tree is None else tree.DIM
         l_factor = tree.l_factor if tree is not None else 1.0
+        capacity = k if tree is None else tree.KListClass.KListNodeClass.CAPACITY
 
-        if tree is None:
-            _, _, KListClass, _ = make_gkplustree_classes(k, dimension=dimension)
-            klist_class = KListClass
-        else:
-            klist_class = tree.KListClass
-        tree = bulk_create_gkplus_tree(entries, dimension, l_factor=l_factor, KListClass=klist_class)
-        logger.debug(f"Tree built via bulk create before unzip: {print_pretty(tree)}")
+        tree = create_gkplus_tree(K=capacity, dimension=dimension, l_factor=l_factor)
+        natural_ranks = calc_ranks(keys, capacity, DIM=dimension)
+        for key, rank in zip(keys, natural_ranks, strict=True):
+            item = self.make_item(key, f"val_{key}")
+            tree, inserted, _ = tree.insert(item, rank=rank)
+            self.assertTrue(inserted, f"Failed to insert item with key {key}")
+        logger.debug(f"Tree built via inserts before unzip: {print_pretty(tree)}")
 
         # Then unzip at key -1 and return the right tree (which should contain all positive keys)
         _left_tree, _key_subtree, right_tree, _next_entry = tree.unzip(-1)
@@ -78,17 +71,12 @@ class TestGKPlusTreeZip(TreeTestCase):
     def _validate_tree_after_zip(self, tree: GKPlusTreeBase, expected_keys: list[int], k: int = 4):
         """Helper to validate tree structure and contents after zip operation."""
         logger.debug(f"k={k}, Expected keys: {expected_keys}")
-        # control_tree = create_gkplus_tree(K=k, dimension=tree.DIM, l_factor=tree.l_factor)
-        # ranks = calc_ranks(expected_keys, k=k, DIM=tree.DIM)
-        control_tree = bulk_create_gkplus_tree(
-            [Entry(self.make_item(key, f"val_{key}"), None) for key in expected_keys],
-            tree.DIM,
-            tree.l_factor,
-            tree.KListClass,
-        )
-        # for key, rank in zip(expected_keys, ranks):
-        #     item = self.make_item(key, f"val_{key}")
-        #     control_tree, _, _ = control_tree.insert(item, rank=rank)
+        capacity = tree.KListClass.KListNodeClass.CAPACITY
+        control_tree = create_gkplus_tree(K=capacity, dimension=tree.DIM, l_factor=tree.l_factor)
+        ranks = calc_ranks(expected_keys, capacity, DIM=tree.DIM)
+        for key, rank in zip(expected_keys, ranks, strict=True):
+            item = self.make_item(key, f"val_{key}")
+            control_tree, _, _ = control_tree.insert(item, rank=rank)
         logger.debug(f"Control tree: {print_pretty(control_tree)}")
         control_stats = asdict(gtree_stats_(control_tree, {}))
         # Check tree invariants
@@ -946,44 +934,20 @@ class TestGKPlusTreeZip(TreeTestCase):
         ranks_large = list(ranks_large)
 
         if order == "small_first":
-            # prepare entries for bulk creation of tree1
-            entries_small = [Entry(self.make_item(k_, f"val_{k_}"), None) for k_ in keys_small]
-            dimension = 1
-            l_factor = 1.0
-            _, _, KListClass, _ = make_gkplustree_classes(k, dimension=dimension)
-            klist_class = KListClass
-
-            # Build the first tree normally
-            tree1 = bulk_create_gkplus_tree(entries_small, dimension, l_factor=l_factor, KListClass=klist_class)
+            # Build the first tree through the public insert interface
+            tree1 = self._create_tree(keys_small, ranks_small, k=k)
 
             # Build the second tree via unzip to test different construction paths
             tree2 = self._create_tree_via_unzip(keys_large, ranks_large, k=k)
 
-            # tree1 = create_gkplus_tree(K=k, dimension=1)
-            # for key, rank in zip(keys_small, ranks_small):
-            #     tree1, _, _ = tree1.insert(self.make_item(key, f"val_{key}"), rank=rank)
-
-            # tree2 = self._create_tree_via_unzip(keys_large, ranks_large, k=k)
             expected_keys = sorted(keys_small + keys_large)
         else:
-            # prepare entries for bulk creation of tree1
-            entries_large = [Entry(self.make_item(k_, f"val_{k_}"), None) for k_ in keys_large]
-            dimension = 1
-            l_factor = 1.0
-            _, _, KListClass, _ = make_gkplustree_classes(k, dimension=dimension)
-            klist_class = KListClass
-
-            # Build the first tree normally
-            tree1 = bulk_create_gkplus_tree(entries_large, dimension, l_factor=l_factor, KListClass=klist_class)
+            # Build the first tree through the public insert interface
+            tree1 = self._create_tree(keys_large, ranks_large, k=k)
 
             # Build the second tree via unzip to test different construction paths
             tree2 = self._create_tree_via_unzip(keys_small, ranks_small, k=k)
 
-            # tree1 = create_gkplus_tree(K=k, dimension=1)
-            # for key, rank in zip(keys_large, ranks_large):
-            #     tree1, _, _ = tree1.insert(self.make_item(key, f"val_{key}"), rank=rank)
-
-            # tree2 = self._create_tree_via_unzip(keys_small, ranks_small, k=k)
             expected_keys = sorted(keys_large + keys_small)
 
         # Log tree structures before zip
@@ -1029,44 +993,20 @@ class TestGKPlusTreeZip(TreeTestCase):
         ranks_large = list(ranks_large)
 
         if order == "small_first":
-            # prepare entries for bulk creation of tree1
-            entries_small = [Entry(self.make_item(k_, f"val_{k_}"), None) for k_ in keys_small]
-            dimension = 1
-            l_factor = 1.0
-            _, _, KListClass, _ = make_gkplustree_classes(k, dimension=dimension)
-            klist_class = KListClass
-
-            # Build the first tree normally
-            tree1 = bulk_create_gkplus_tree(entries_small, dimension, l_factor=l_factor, KListClass=klist_class)
+            # Build the first tree through the public insert interface
+            tree1 = self._create_tree(keys_small, ranks_small, k=k)
 
             # Build the second tree via unzip to test different construction paths
             tree2 = self._create_tree_via_unzip(keys_large, ranks_large, k=k)
 
-            # tree1 = create_gkplus_tree(K=k, dimension=1)
-            # for key, rank in zip(keys_small, ranks_small):
-            #     tree1, _, _ = tree1.insert(self.make_item(key, f"val_{key}"), rank=rank)
-
-            # tree2 = self._create_tree_via_unzip(keys_large, ranks_large, k=k)
             expected_keys = sorted(keys_small + keys_large)
         else:
-            # prepare entries for bulk creation of tree1
-            entries_large = [Entry(self.make_item(k_, f"val_{k_}"), None) for k_ in keys_large]
-            dimension = 1
-            l_factor = 1.0
-            _, _, KListClass, _ = make_gkplustree_classes(k, dimension=dimension)
-            klist_class = KListClass
-
-            # Build the first tree normally
-            tree1 = bulk_create_gkplus_tree(entries_large, dimension, l_factor=l_factor, KListClass=klist_class)
+            # Build the first tree through the public insert interface
+            tree1 = self._create_tree(keys_large, ranks_large, k=k)
 
             # Build the second tree via unzip to test different construction paths
             tree2 = self._create_tree_via_unzip(keys_small, ranks_small, k=k)
 
-            # tree1 = create_gkplus_tree(K=k, dimension=1)
-            # for key, rank in zip(keys_large, ranks_large):
-            #     tree1, _, _ = tree1.insert(self.make_item(key, f"val_{key}"), rank=rank)
-
-            # tree2 = self._create_tree_via_unzip(keys_small, ranks_small, k=k)
             expected_keys = sorted(keys_large + keys_small)
 
         # Log tree structures before zip
@@ -1115,44 +1055,20 @@ class TestGKPlusTreeZip(TreeTestCase):
         ranks_large = list(ranks_large)
 
         if order == "small_first":
-            # prepare entries for bulk creation of tree1
-            entries_small = [Entry(self.make_item(k_, f"val_{k_}"), None) for k_ in keys_small]
-            dimension = 1
-            l_factor = 1.0
-            _, _, KListClass, _ = make_gkplustree_classes(k, dimension=dimension)
-            klist_class = KListClass
-
-            # Build the first tree normally
-            tree1 = bulk_create_gkplus_tree(entries_small, dimension, l_factor=l_factor, KListClass=klist_class)
+            # Build the first tree through the public insert interface
+            tree1 = self._create_tree(keys_small, ranks_small, k=k)
 
             # Build the second tree via unzip to test different construction paths
             tree2 = self._create_tree_via_unzip(keys_large, ranks_large, k=k)
 
-            # tree1 = create_gkplus_tree(K=k, dimension=1)
-            # for key, rank in zip(keys_small, ranks_small):
-            #     tree1, _, _ = tree1.insert(self.make_item(key, f"val_{key}"), rank=rank)
-
-            # tree2 = self._create_tree_via_unzip(keys_large, ranks_large, k=k)
             expected_keys = sorted(keys_small + keys_large)
         else:
-            # prepare entries for bulk creation of tree1
-            entries_large = [Entry(self.make_item(k_, f"val_{k_}"), None) for k_ in keys_large]
-            dimension = 1
-            l_factor = 1.0
-            _, _, KListClass, _ = make_gkplustree_classes(k, dimension=dimension)
-            klist_class = KListClass
-
-            # Build the first tree normally
-            tree1 = bulk_create_gkplus_tree(entries_large, dimension, l_factor=l_factor, KListClass=klist_class)
+            # Build the first tree through the public insert interface
+            tree1 = self._create_tree(keys_large, ranks_large, k=k)
 
             # Build the second tree via unzip to test different construction paths
             tree2 = self._create_tree_via_unzip(keys_small, ranks_small, k=k)
 
-            # tree1 = create_gkplus_tree(K=k, dimension=1)
-            # for key, rank in zip(keys_large, ranks_large):
-            #     tree1, _, _ = tree1.insert(self.make_item(key, f"val_{key}"), rank=rank)
-
-            # tree2 = self._create_tree_via_unzip(keys_small, ranks_small, k=k)
             expected_keys = sorted(keys_large + keys_small)
 
         # Log tree structures before zip

--- a/tests/gk_plus/test_insert_dimensions.py
+++ b/tests/gk_plus/test_insert_dimensions.py
@@ -2,6 +2,7 @@ import copy
 import logging
 from typing import ClassVar
 
+from gplus_trees.base import Entry
 from gplus_trees.g_k_plus.factory import create_gkplus_tree
 from gplus_trees.g_k_plus.utils import calc_rank
 from gplus_trees.gplus_tree_base import print_pretty
@@ -183,3 +184,115 @@ class TestInsertMultipleDimensions(TreeTestCase):
                 self._run_insert_case_multi_dim(
                     keys, ranks, insert_pair, exp_keys, case_name, gnode_capacity=4, l_factor=1.0
                 )
+
+
+class TestGrowthAcrossConversionThreshold(TreeTestCase):
+    """Interface-level coverage for the bulk build of deeper dimensions.
+
+    Growing a tree past the conversion threshold (k · l_factor) through
+    ``insert_entry`` drives the entire internal growth path: KList
+    expansion, conversion, and the bottom-up bulk build of the
+    dimension-d+1 tree.  These tests assert only observable behaviour
+    (max dimension, expanded-leaf count, item counts, iteration order,
+    retrievability), so they exercise the conversion / bulk-create
+    internals without importing them and survive internal refactors.
+    """
+
+    def _insert_all(self, tree, keys, ranks):
+        for key, rank in zip(keys, ranks, strict=True):
+            entry = Entry(self.make_item(key, f"val_{key}"), None)
+            tree, inserted, _ = tree.insert_entry(entry, rank)
+            self.assertTrue(inserted, f"Failed to insert key {key}")
+        return tree
+
+    def _assert_all_retrievable(self, tree, keys):
+        for key in keys:
+            entry, _ = tree.retrieve(key)
+            self.assertIsNotNone(entry, f"Key {key} must be retrievable after growth")
+            self.assertEqual(entry.item.key, key)
+            self.assertEqual(entry.item.value, f"val_{key}", f"Value of key {key} must survive expansion")
+
+    def _assert_sorted_real_keys(self, tree, keys):
+        actual = [e.item.key for e in tree.iter_real_entries()]
+        self.assertEqual(sorted(keys), actual, "Real entries must iterate in sorted key order")
+
+    def test_growth_across_threshold_expands_leaf(self):
+        """Crossing k · l_factor in a leaf set must expand it into a
+        dimension-2 tree (built via the internal bulk path); staying at
+        the threshold must not."""
+        k = 4  # threshold = k * l_factor = 4 (leaf set holds the dummy too)
+        keys = self.find_keys_for_rank_lists([[1, 1, 1, 1]], k=k)
+
+        # Below/at threshold: dummy + 3 keys == 4 items -> no expansion.
+        tree = create_gkplus_tree(K=k, dimension=1, l_factor=1.0)
+        tree = self._insert_all(tree, keys[:3], [1] * 3)
+        self.assertEqual(tree.get_max_dim(), 1, "At the threshold no deeper dimension may exist")
+        self.assertEqual(tree.get_expanded_leaf_count(), 0)
+
+        # One more same-rank key pushes the leaf set past the threshold.
+        tree = self._insert_all(tree, keys[3:], [1])
+        self.assertGreaterEqual(tree.get_max_dim(), 2, "Crossing the threshold must create dimension >= 2")
+        self.assertGreaterEqual(tree.get_expanded_leaf_count(), 1)
+
+        exp_keys = sorted(self.get_dummies(tree) + keys)
+        self.validate_tree(tree, exp_keys)
+        self._assert_all_retrievable(tree, keys)
+        self._assert_sorted_real_keys(tree, keys)
+        self.assertEqual(tree.real_item_count(), len(keys))
+
+    def test_growth_threshold_scales_with_l_factor(self):
+        """With l_factor=2.0 the same capacity tolerates twice the items
+        before expanding: dummy + 7 == 8 items stay flat, the 8th key
+        triggers the dimension-2 bulk build."""
+        k = 4  # threshold = k * l_factor = 8
+        keys = self.find_keys_for_rank_lists([[1] * 8], k=k)
+
+        tree = create_gkplus_tree(K=k, dimension=1, l_factor=2.0)
+        tree = self._insert_all(tree, keys[:7], [1] * 7)
+        self.assertEqual(tree.get_max_dim(), 1, "l_factor=2.0 must defer expansion until 8 items")
+        self.assertEqual(tree.get_expanded_leaf_count(), 0)
+
+        tree = self._insert_all(tree, keys[7:], [1])
+        self.assertGreaterEqual(tree.get_max_dim(), 2)
+        self.assertGreaterEqual(tree.get_expanded_leaf_count(), 1)
+
+        exp_keys = sorted(self.get_dummies(tree) + keys)
+        self.validate_tree(tree, exp_keys)
+        self._assert_all_retrievable(tree, keys)
+
+    def test_growth_into_nested_dimensions(self):
+        """Keys colliding at rank 1 in dimensions 1 AND 2 force the bulk
+        build to recurse: the expanded dimension-2 set itself exceeds the
+        threshold and expands further."""
+        k = 4
+        keys = self.find_keys_for_rank_lists([[1] * 5, [1] * 5], k=k)
+
+        tree = create_gkplus_tree(K=k, dimension=1, l_factor=1.0)
+        tree = self._insert_all(tree, keys, [1] * len(keys))
+
+        self.assertGreaterEqual(tree.get_max_dim(), 3, "Double rank collision must nest beyond dimension 2")
+        exp_keys = sorted(self.get_dummies(tree) + keys)
+        self.validate_tree(tree, exp_keys)
+        self._assert_all_retrievable(tree, keys)
+        self._assert_sorted_real_keys(tree, keys)
+
+    def test_growth_sequential_keys_natural_ranks(self):
+        """Sequential keys with their natural (digest-derived) ranks grow
+        past the threshold in many leaves; structure, counts, ordering
+        and retrievability must hold throughout."""
+        k = 4
+        keys = list(range(1, 301))
+        ranks = [calc_rank(key=key, k=k, dim=1) for key in keys]
+
+        tree = create_gkplus_tree(K=k, dimension=1, l_factor=1.0)
+        tree = self._insert_all(tree, keys, ranks)
+
+        self.assertGreaterEqual(tree.get_max_dim(), 2, "300 keys at K=4 must expand at least one leaf")
+        self.assertGreaterEqual(tree.get_expanded_leaf_count(), 1)
+        self.assertEqual(tree.real_item_count(), len(keys))
+
+        exp_keys = sorted(self.get_dummies(tree) + keys)
+        self.validate_tree(tree, exp_keys)
+        self._assert_sorted_real_keys(tree, keys)
+        self._assert_all_retrievable(tree, keys)
+        self.assertTrue(self.verify_subtree_sizes(tree))

--- a/tests/gk_plus/test_set_conversion.py
+++ b/tests/gk_plus/test_set_conversion.py
@@ -776,11 +776,11 @@ class TestCheckAndCollapseTree(TestSetConversion):
         self.assertIsInstance(result, GKPlusTreeBase, "Large tree should remain a GKPlusTree")
 
 
-# ─── convert_node_set contract tests ───────────────────────────────
+# ─── _convert_node_set contract tests ───────────────────────────────
 
 
 class TestConvertNodeSet(TestSetConversion):
-    """Contract tests for ``convert_node_set``: it replaces ``node.set``
+    """Contract tests for ``_convert_node_set``: it replaces ``node.set``
     AND invalidates the owning tree's cached counts, so callers carry no
     follow-up contract (previously TODO(#1) in conversion.py)."""
 
@@ -815,13 +815,13 @@ class TestConvertNodeSet(TestSetConversion):
         old_count = tree.item_count()
         self.assertEqual(tree.item_cnt, old_count, "cache should be populated before conversion")
 
-        tree.convert_node_set(tree.node)
+        tree._convert_node_set(tree.node)
 
         self.assertIsInstance(tree.node.set, GKPlusTreeBase, "over-threshold KList should expand")
         self.assertEqual(tree.node.set.DIM, 2)
-        self.assertIsNone(tree.item_cnt, "item_cnt must be invalidated by convert_node_set")
-        self.assertIsNone(tree.size, "size must be invalidated by convert_node_set")
-        self.assertIsNone(tree.expanded_cnt, "expanded_cnt must be invalidated by convert_node_set")
+        self.assertIsNone(tree.item_cnt, "item_cnt must be invalidated by _convert_node_set")
+        self.assertIsNone(tree.size, "size must be invalidated by _convert_node_set")
+        self.assertIsNone(tree.expanded_cnt, "expanded_cnt must be invalidated by _convert_node_set")
         # The recomputed count sees the new dimension's dummy; a stale
         # cache would still report old_count.
         self.assertEqual(tree.item_count(), old_count + 1)
@@ -834,22 +834,22 @@ class TestConvertNodeSet(TestSetConversion):
         old_count = tree.item_count()
         self.assertEqual(tree.item_cnt, old_count, "cache should be populated before conversion")
 
-        tree.convert_node_set(tree.node)
+        tree._convert_node_set(tree.node)
 
         self.assertIsInstance(tree.node.set, KListBase, "undersized inner tree should collapse")
-        self.assertIsNone(tree.item_cnt, "item_cnt must be invalidated by convert_node_set")
+        self.assertIsNone(tree.item_cnt, "item_cnt must be invalidated by _convert_node_set")
         self.assertEqual(tree.item_count(), tree.node.set.item_count(), "recount must match the converted set")
 
     def test_no_op_still_invalidates(self):
         """No conversion needed: the set stays, the caches are still
-        invalidated (callsites reach convert_node_set only after mutating
+        invalidated (callsites reach _convert_node_set only after mutating
         the node, so the caches are stale either way)."""
         tree = self._make_leaf_tree()
         klist = tree.node.set
         tree.item_count()
         self.assertIsNotNone(tree.item_cnt)
 
-        tree.convert_node_set(tree.node)
+        tree._convert_node_set(tree.node)
 
         self.assertIs(tree.node.set, klist, "under-threshold KList must stay untouched")
         self.assertIsNone(tree.item_cnt, "item_cnt must be invalidated even without conversion")


### PR DESCRIPTION
## Why

The growth path (insert → conversion → bulk build of the deeper dimension) spans `insert.py`, `conversion.py` and `bulk_create.py` but exposed its inner workings as interface: callers and tests knew `insert_entry()`, `check_and_convert_set()`, `convert_node_set()` and `bulk_create_gkplus_tree()` side by side, and `bulk_create.py` (~470 LOC) had no coverage of its own. Understanding one insert meant reading the whole cluster; bugs live in the interplay that no single seam owned. The removed re-exports from #14 were the groundwork — this shrinks the cluster's external interface to the insertion entry point.

## What

- `bulk_create_gkplus_tree` → `_bulk_create_gkplus_tree`, `check_and_convert_set` → `_check_and_convert_set`, `convert_node_set` → `_convert_node_set` (underscore convention, following `_RankData`, `_klist_to_tree`, `_tree_to_klist`). Module docstrings now state the seam discipline: outside the `g_k_plus` package, growth is reachable only through `insert_entry()`. The file decomposition is untouched — depth is a property of the interface, not the file structure.
- `zip.py` keeps its direct bulk-create calls instead of routing through the conversion seam: type normalization before merging must convert a KList at or below the threshold **unconditionally**, which the threshold-gated `_check_and_convert_set()` cannot express without changing behaviour (it would leave the sets type-mismatched and zip would raise). Documented at the callsite.
- Benchmarks and zip tests no longer import bulk internals: fixture trees are built through the factory plus `insert_entry()`/`insert()`. GK+-trees are canonical, so the structures are identical — verified empirically for both benchmark setups (sequential keys at DIM=1, adversarial keys at DIM=dim_limit, all K × l_factor combinations: equal `gtree_stats_`, pretty-print and iteration order).
- New interface-level tests cover the bulk build through `insert_entry()`: leaf expansion exactly past `k · l_factor`, threshold scaling with `l_factor`, nested expansion via rank collisions across two dimensions, and 300 sequential keys with natural ranks. Existing white-box tests of the internals stay and only follow the renames.

Found in passing, pre-existing and out of scope here: inserting two keys that share rank 1 at dimension 1 into a K=2 tree recurses without bound in the bulk expansion (`RecursionError`); reproduced on `main`. Tracked separately.

## How to verify

```
./.venv/bin/pytest                                        # 486 tests + 1040 subtests
./.venv/bin/pytest tests/gk_plus/test_insert_dimensions.py  # new growth tests
./.venv/bin/ruff check . && ./.venv/bin/ruff format --check .
grep -rn "from gplus_trees.g_k_plus.bulk_create import" tests/ stats/ benchmarks/
# → only tests/gk_plus/test_set_conversion.py (deliberate white-box tests)
```