### PR TITLE
fix(gplus): make get_dummy cache call-style-independent

### DIFF
--- a/src/gplus_trees/gplus_tree_base.py
+++ b/src/gplus_trees/gplus_tree_base.py
@@ -46,14 +46,22 @@ DUMMY_ITEM = DummyItem(ItemData(key=DUMMY_KEY))
 
 
 @functools.cache
+def _get_dummy_cached(dim: int) -> DummyItem:
+    return DummyItem(ItemData(key=-(dim)))
+
+
 def get_dummy(dim: int) -> DummyItem:
     """Return a cached :class:`DummyItem` for the given dimension.
 
     The key is ``-dim`` (e.g. dimension 1 → key ``-1``, dimension 2 → key ``-2``).
     Results are cached so successive calls for the same *dim* return the
-    identical object.
+    identical object — regardless of call style: ``functools.cache`` keys
+    positional and keyword calls separately, so the cache lives on a private
+    helper that this wrapper always calls positionally
+    (``get_dummy(1) is get_dummy(dim=1)`` must hold; identity checks such as
+    ``item is dummy`` in :mod:`gplus_trees.invariants` rely on it).
     """
-    return DummyItem(ItemData(key=-(dim)))
+    return _get_dummy_cached(dim)
 
 
 class _SplitContext:

--- a/tests/gk_plus/test_insert.py
+++ b/tests/gk_plus/test_insert.py
@@ -6,7 +6,9 @@ from typing import ClassVar
 
 from gplus_trees.base import Entry
 from gplus_trees.g_k_plus.factory import create_gkplus_tree
-from gplus_trees.gplus_tree_base import print_pretty
+from gplus_trees.g_k_plus.utils import calc_ranks_multi_dims
+from gplus_trees.gplus_tree_base import get_dummy, print_pretty
+from gplus_trees.invariants import check_leaf_keys_and_values
 from tests.test_base import GKPlusTreeTestCase
 
 logger = logging.getLogger(__name__)
@@ -559,3 +561,51 @@ class TestGKPlusNegativeKeyGuard(GKPlusTreeTestCase):
         found, _ = tree.retrieve(0)
         self.assertIsNotNone(found)
         self.assertEqual(found.item.value, "v")
+
+
+class TestGKPlusLeafDummyIdentity(GKPlusTreeTestCase):
+    """Leaf-identity contract for GK+-trees: every dummy circulating in leaf
+    sets must be *the* cached sentinel of its dimension, because invariant
+    checks compare by identity (``item is dummy``).
+
+    Regression: ``get_dummy`` was cached with ``@functools.cache`` directly,
+    which keys positional and keyword calls separately.  Leaf construction
+    (positional calls) and :func:`check_leaf_keys_and_values` (keyword call)
+    therefore held two distinct sentinels per dimension, and ``order_ok``
+    was misreported as ``False`` for every GK+-tree.
+    """
+
+    def test_check_leaf_keys_reports_order_ok(self):
+        # Small tree without leaf expansion: the only dummy is the tree's
+        # dim-1 sentinel, so order_ok isolates the identity contract.
+        tree = create_gkplus_tree(K=4)
+        for key, rank in [(3, 1), (7, 2), (12, 1)]:
+            tree, _, _ = tree.insert(self.make_item(key, f"v{key}"), rank)
+        self.assertEqual(tree.get_expanded_leaf_count(), 0, "premise: no expanded leaf sets")
+
+        keys, presence_ok, _, order_ok = check_leaf_keys_and_values(tree, [3, 7, 12])
+        self.assertTrue(order_ok, f"order_ok misreported for sorted leaf keys {keys}")
+        self.assertTrue(presence_ok)
+
+    def test_expanded_leaf_dummies_are_canonical_sentinels(self):
+        # Dimension expansion creates dummies for dims > 1; each must be the
+        # cached sentinel of its dimension, no matter which call style the
+        # constructing code path used.
+        keys = [5, 2, 9, 1, 7, 3, 8, 4, 6, 10, 15, 12, 20]
+        ranks = calc_ranks_multi_dims(keys, 4, dimensions=1)[0]
+        tree = create_gkplus_tree(K=4)
+        for key, rank in zip(keys, ranks, strict=True):
+            tree, _, _ = tree.insert(self.make_item(key, f"v{key}"), rank)
+        self.assertGreater(tree.get_expanded_leaf_count(), 0, "premise: expanded leaf sets exist")
+
+        first_item = next(iter(next(iter(tree.iter_leaf_nodes())).set)).item
+        self.assertIs(first_item, tree._get_dummy(), "first leaf item must be the tree's own sentinel")
+
+        for leaf in tree.iter_leaf_nodes():
+            for entry in leaf.set:
+                if entry.item.key < 0:
+                    self.assertIs(
+                        entry.item,
+                        get_dummy(-entry.item.key),
+                        f"dummy with key {entry.item.key} is not the cached sentinel of its dimension",
+                    )

--- a/tests/gplus/test_gplus_tree_base.py
+++ b/tests/gplus/test_gplus_tree_base.py
@@ -276,6 +276,16 @@ class TestGetDummy(unittest.TestCase):
         b = get_dummy(dim=3)
         self.assertIs(a, b, "lru_cache should return the identical object")
 
+    def test_positional_and_keyword_calls_share_cache(self):
+        # Regression: functools.cache keys positional and keyword calls
+        # separately; a direct @functools.cache on get_dummy handed out two
+        # distinct sentinels per dimension, breaking `item is dummy` checks.
+        self.assertIs(
+            get_dummy(1),
+            get_dummy(dim=1),
+            "get_dummy must return the identical sentinel regardless of call style",
+        )
+
     def test_different_dims_return_different_objects(self):
         a = get_dummy(dim=1)
         b = get_dummy(dim=2)


### PR DESCRIPTION
## Why

`get_dummy(dim)` in `src/gplus_trees/gplus_tree_base.py` was decorated directly
with `functools.cache`. `functools.cache` keys positional and keyword calls
separately, so `get_dummy(1)` and `get_dummy(dim=1)` returned **two distinct**
`DummyItem` sentinels for the same dimension.

Leaf construction in `src/gplus_trees/g_k_plus/insert.py` calls `get_dummy(dim)`
positionally, while the invariant checker resolves its sentinel via
`get_dummy(dim=dim)` (`src/gplus_trees/invariants.py`). The identity check
`item is not dummy` in `check_leaf_keys_and_values` therefore compared two
different objects and misreported `order_ok=False` for **every** Gᵏ⁺-tree with
correctly sorted leaf keys.

The defect stayed invisible because the `order_ok` assertion runs in
`BaseTreeTestCase.tearDown`, but no Gᵏ⁺ test assigns `self.tree`, so the check
never fired for Gᵏ⁺-trees.

## What

- **`src/gplus_trees/gplus_tree_base.py`**: the cache now lives on a private
  `_get_dummy_cached(dim)`; the public `get_dummy` is a thin wrapper that always
  forwards positionally. Both call styles now return the identical object, and
  the identity contract can't silently break again on a future keyword call.
- **`tests/gplus/test_gplus_tree_base.py`**: unit regression asserting
  `get_dummy(1) is get_dummy(dim=1)`.
- **`tests/gk_plus/test_insert.py`**: new `TestGKPlusLeafDummyIdentity` —
  (a) `order_ok=True` for a non-expanded Gᵏ⁺-tree (was `False` before the fix),
  (b) in a tree with expanded leaf sets, every leaf dummy is the canonical
  sentinel of its dimension and the first leaf entry `is tree._get_dummy()`.

## How to verify

```
./.venv/bin/pytest tests/gplus/test_gplus_tree_base.py tests/gk_plus/test_insert.py -k "GetDummy or LeafDummyIdentity"
./.venv/bin/pytest      # full suite: 485 passed, 1040 subtests
./.venv/bin/ruff check . && ./.venv/bin/ruff format --check .
```

## Follow-ups (out of scope, tracked separately)

- `check_leaf_keys_and_values` still misreports `order_ok`/`presence_ok` for
  **expanded** Gᵏ⁺ leaf sets, for a second independent reason: it does not skip
  the higher-dimension dummies (keys −2, −3, …). This PR fixes only the identity
  split; making the checker expansion-aware is separate.
- Many equal-rank inserts into a small (K=2) Gᵏ⁺-tree trigger an unbounded
  dimension-expansion cascade in `bulk_create` and crash with `RecursionError`.
