### PR TITLE
fix(gkplus): exempt carried dummies from conversion threshold count

### DIFF
--- a/docs/adr/0003-conversion-threshold-counts-own-dimension-entries.md
+++ b/docs/adr/0003-conversion-threshold-counts-own-dimension-entries.md
@@ -1,0 +1,34 @@
+# ADR-0003: Conversion threshold counts only own-dimension entries
+
+**Status:** Accepted · **Date:** 2026-07-06
+
+## Context
+
+The KList↔tree conversion threshold (ADR-0002) compared `item_count()`, which
+includes dummies carried in from other dimensions. Carried dummies accumulate
+by one per expansion level, so once enough of them shared a node the threshold
+became unsatisfiable: with K=2, l_factor=1.0, a node holding two carried
+dummies plus one real key stays above the threshold in every dimension, and
+bulk creation recursed through dimensions without bound (RecursionError).
+Under that counting rule the canonical structure for such inputs does not
+exist — it would be infinitely deep.
+
+## Decision
+
+Only entries of the set's own dimension weigh against the conversion
+threshold: real items (key ≥ 0) and the owning tree's own dummy
+(key = −DIM). Dummies carried in from other dimensions are exempt.
+Expansion, collapse, and the `set_thresholds_met` invariant all share this
+counting rule (`bulk_create._threshold_item_count`), keeping the conversion
+hysteresis-free (ADR-0002).
+
+## Consequences
+
+- Dimensional recursion terminates: expansion beyond dimension d+1 requires
+  more than `k·l_factor` counting entries in a node, and once the real keys'
+  ranks diverge, leaf counts drop below the threshold regardless of how many
+  carried dummies share the node.
+- Structures without carried dummies are unchanged — the count equals the old
+  `item_count()` there.
+- A node set's KList form may exceed `k·l_factor` raw items (carried dummies
+  on top of counting entries); that is expected, not an invariant violation.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,8 @@ work.
 | # | Title | Status | Date |
 |---|-------|--------|------|
 | [0001](0001-terminology-precedence.md) | Terminology precedence — paper over thesis over repo | Accepted | 2026-07-02 |
+| [0002](0002-hysteresis-free-conversion-threshold.md) | Hysteresis-free conversion threshold | Accepted | 2026-07-02 |
+| [0003](0003-conversion-threshold-counts-own-dimension-entries.md) | Conversion threshold counts only own-dimension entries | Accepted | 2026-07-06 |
 
 ## Format
 

--- a/src/gplus_trees/g_k_plus/bulk_create.py
+++ b/src/gplus_trees/g_k_plus/bulk_create.py
@@ -34,6 +34,7 @@ Complexity summary (n = entries, k = KList capacity, h = resulting height):
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from itertools import islice
 
 from gplus_trees.base import (
@@ -160,6 +161,18 @@ def _bulk_create_klist(entries: list[Entry], KListClass: type[KListBase]) -> KLi
     return klist
 
 
+def _threshold_item_count(entries: Iterable[Entry], own_dummy_key: int) -> int:
+    """Count the entries that weigh against the conversion threshold.
+
+    Real items (key >= 0) and the tree's own dummy (key == own_dummy_key)
+    count; dummies carried in from other dimensions do not.  Carried
+    dummies accumulate by one per expansion level, so counting them can
+    keep a node above the threshold forever even after the real keys have
+    separated — the dimensional recursion would never terminate.
+    """
+    return sum(1 for e in entries if e.item.key >= 0 or e.item.key == own_dummy_key)
+
+
 def _build_leaf_level_trees(
     rank_data_map: dict[int, _RankData],
     KListClass: type[KListBase],
@@ -185,6 +198,7 @@ def _build_leaf_level_trees(
     boundaries_map = rank_1_data.boundaries
 
     threshold = KListClass.KListNodeClass.CAPACITY * l_factor
+    own_dummy_key = get_dummy(TreeClass.DIM).key
     leaf_trees = []
     prev_node = None
 
@@ -193,7 +207,7 @@ def _build_leaf_level_trees(
         end_idx = boundaries_map[i + 1] if i + 1 < len(boundaries_map) else len(entries)
         node_entries = entries[start_idx:end_idx]
 
-        if len(node_entries) <= threshold:
+        if _threshold_item_count(node_entries, own_dummy_key) <= threshold:
             node_set = _bulk_create_klist(node_entries, KListClass)
         else:
             node_set = _bulk_create_gkplus_tree(node_entries, TreeClass.DIM + 1, l_factor, KListClass)
@@ -240,6 +254,7 @@ def _build_internal_levels(
     bulk_create_klist_fn = _bulk_create_klist
     bulk_create_gkplus_tree_fn = _bulk_create_gkplus_tree
     tree_dim_plus_one = TreeClass.DIM + 1
+    own_dummy_key = get_dummy(TreeClass.DIM).key
 
     rank = 2
     sub_trees = leaf_trees
@@ -293,8 +308,7 @@ def _build_internal_levels(
                 prev_child_idx = child_idx
 
             # Create node set
-            node_entries_len = len(node_entries)
-            if node_entries_len <= threshold:
+            if _threshold_item_count(node_entries, own_dummy_key) <= threshold:
                 node_set = bulk_create_klist_fn(node_entries, KListClass)
             else:
                 node_set = bulk_create_gkplus_tree_fn(node_entries, tree_dim_plus_one, l_factor, KListClass)

--- a/src/gplus_trees/g_k_plus/conversion.py
+++ b/src/gplus_trees/g_k_plus/conversion.py
@@ -4,8 +4,11 @@ Provides :class:`GKPlusConversionMixin`, a mixin class that adds
 ``_convert_node_set`` and ``_check_and_convert_set`` to
 :class:`GKPlusTreeBase`.
 
-Conversions are triggered when a KList exceeds ``k · l_factor`` items
-(expand) or a GKPlusTree shrinks below that threshold (collapse).
+Conversions are triggered when a KList exceeds ``k · l_factor``
+threshold-counting items (expand) or a GKPlusTree falls to or below
+that threshold (collapse).  Only real items and the owning tree's own
+dummy count toward the threshold; dummies carried in from other
+dimensions do not (see ``bulk_create._threshold_item_count``).
 These conversions are what create recursive dimensional nesting:
 an expanded KList becomes a GK+-tree of the next dimension.
 
@@ -45,7 +48,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from gplus_trees.base import AbstractSetDataStructure
-from gplus_trees.g_k_plus.bulk_create import _klist_to_tree, _tree_to_klist
+from gplus_trees.g_k_plus.bulk_create import _klist_to_tree, _threshold_item_count, _tree_to_klist
 from gplus_trees.klist_base import KListBase
 
 if TYPE_CHECKING:
@@ -100,7 +103,13 @@ class GKPlusConversionMixin:
         # Check if the item count exceeds l_factor * CAPACITY
         k = klist.KListNodeClass.CAPACITY
         threshold = int(k * self.l_factor)
-        if klist.item_count() > threshold:
+        if klist.item_count() <= threshold:
+            return klist
+
+        # The raw count exceeds the threshold, but only entries of this
+        # tree's own dimension weigh against it (see _threshold_item_count:
+        # counting carried dummies would make the threshold unsatisfiable).
+        if _threshold_item_count(klist, self.dummy_item.key) > threshold:
             # Convert to GKPlusTree with increased dimension
             new_dim = type(self).DIM + 1
             new_tree = _klist_to_tree(klist, k, new_dim, self.l_factor)
@@ -119,20 +128,19 @@ class GKPlusConversionMixin:
             Either the original tree or a new KList based on the threshold
 
         Implementation note:
-            An early-exit loop counts real items (key ≥ 0) and aborts as
-            soon as the count exceeds the collapse threshold.  This is
-            O(threshold) = O(k) instead of O(n), because we stop after
-            seeing threshold + 1 real items.
-
-            When the count stays ≤ threshold the tree is small enough to
-            speculatively convert via ``_tree_to_klist`` and verify the
-            actual KList size (which may be slightly larger due to
-            lower-dimension dummies that are preserved).
+            An early-exit loop counts the entries that weigh against the
+            threshold — real items (key ≥ 0) and the receiver's own
+            dummy — and aborts as soon as the count exceeds the collapse
+            threshold.  This is O(threshold) = O(k) instead of O(n),
+            because we stop after seeing threshold + 1 counting entries.
+            Dummies carried in from other dimensions are excluded, using
+            the same counting rule as the expansion check — the shared
+            rule is what keeps the conversion hysteresis-free (ADR-0002).
 
             Empty GKPlusTree sets (artifacts of unzip splits) are
             converted to empty KLists unconditionally, since an empty
             GKPlusTree would violate the ``set_thresholds_met`` invariant
-            (every GKPlusTree inner set must have item_count > threshold).
+            (every GKPlusTree inner set must exceed the threshold).
         """
         k = self.KListClass.KListNodeClass.CAPACITY
         threshold = int(k * self.l_factor)
@@ -144,29 +152,21 @@ class GKPlusConversionMixin:
         if tree.is_empty():
             # Convert to an empty KList rather than keeping an empty
             # GKPlusTree, which would violate the set_thresholds_met
-            # invariant (a GKPlusTree set must have item_count > threshold).
+            # invariant (a GKPlusTree set must exceed the threshold).
             return _tree_to_klist(tree)
 
-        # Early-exit real-item count: iterate the tree's entries and
-        # count items with key >= 0, stopping as soon as the count
-        # exceeds the collapse threshold.  This is O(threshold) instead
-        # of O(n) because we abort after seeing threshold+1 real items.
-        real_count = 0
+        # Early-exit counting: iterate the tree's entries and stop as
+        # soon as the count exceeds the collapse threshold.  Iterating
+        # *tree* also yields dummies of dimensions above the receiver's
+        # (the inner tree's own sentinel and deeper ones); the equality
+        # check excludes those alongside the carried lower-dimension ones.
+        own_dummy_key = self.dummy_item.key
+        counted = 0
         for entry in tree:
-            if entry.item.key >= 0:
-                real_count += 1
-                if real_count > threshold:
+            key = entry.item.key
+            if key >= 0 or key == own_dummy_key:
+                counted += 1
+                if counted > threshold:
                     return tree
 
-        # The tree has few enough real items that it may fit in a KList.
-        # Convert and verify the resulting size (which also includes
-        # lower-dimension dummies that _tree_to_klist preserves).
-        new_klist = _tree_to_klist(tree)
-        klist_size = new_klist.item_count()
-
-        if klist_size <= threshold:
-            return new_klist
-
-        # Resulting KList exceeds the threshold (due to preserved
-        # lower-dimension dummies).  Keep the tree structure.
-        return tree
+        return _tree_to_klist(tree)

--- a/src/gplus_trees/tree_stats.py
+++ b/src/gplus_trees/tree_stats.py
@@ -94,6 +94,14 @@ def gtree_stats_(
     node_item_count = node_set.item_count()
     rank_hist[node_rank] = rank_hist.get(node_rank, 0) + node_set.item_count()
 
+    # Entries that weigh against the KList↔tree conversion threshold:
+    # real items plus this tree's own dummy.  Dummies carried in from
+    # other dimensions do not count — same rule as the conversion logic
+    # in g_k_plus.conversion / g_k_plus.bulk_create (counting them would
+    # make the threshold unsatisfiable once enough of them share a node).
+    # For variants without carried dummies this equals item_count().
+    node_threshold_count = sum(1 for e in node_set if e.item.key >= 0 or e.item.key == dummy_key)
+
     # ---------- check inner (higher-dimension) tree if node_set is a GKPlusTreeBase ----
     # When a KList overflows, it is replaced by a recursively instantiated
     # GKPlusTreeBase at dimension D+1.  That inner tree has its own structural
@@ -187,8 +195,8 @@ def gtree_stats_(
 
             # Check current node violations (only if no child violations yet)
             if stats.set_thresholds_met and (
-                (isinstance(node_set, KListBase) and node_set.item_count() > threshold)
-                or (not isinstance(node_set, KListBase) and node_set.item_count() <= threshold)
+                (isinstance(node_set, KListBase) and node_threshold_count > threshold)
+                or (not isinstance(node_set, KListBase) and node_threshold_count <= threshold)
             ):
                 stats.set_thresholds_met = False
 
@@ -220,8 +228,8 @@ def gtree_stats_(
         stats.set_thresholds_met = False
 
     # Check current node violations (always check, regardless of current state)
-    if (isinstance(node_set, KListBase) and node_set.item_count() > threshold) or (
-        not isinstance(node_set, KListBase) and node_set.item_count() <= threshold
+    if (isinstance(node_set, KListBase) and node_threshold_count > threshold) or (
+        not isinstance(node_set, KListBase) and node_threshold_count <= threshold
     ):
         stats.set_thresholds_met = False
 

--- a/tests/gk_plus/test_set_conversion.py
+++ b/tests/gk_plus/test_set_conversion.py
@@ -152,11 +152,15 @@ class TestKListToTree(TestSetConversion):
         self.assertIsInstance(tree.node.set.node.set, KListBase)
 
     def test_expansion_rank_1_dim_gt_1(self):
+        # Four real keys: the expansion decision counts only real items
+        # and the tree's own dummy (carried dummies like the -2
+        # representative below are exempt), so k+1 real keys are needed
+        # to push the DIM-3 leaf over the threshold.
         rank_lists = [
-            [1, 1, 1],  # Dimension 1
-            [1, 1, 1],  # Dimension 2
-            [1, 1, 1],  # Dimension 3 (conversion)
-            [2, 1, 1],  # Dimension 4 (expansion and stopping)
+            [1, 1, 1, 1],  # Dimension 1
+            [1, 1, 1, 1],  # Dimension 2
+            [1, 1, 1, 1],  # Dimension 3 (conversion)
+            [2, 1, 1, 1],  # Dimension 4 (expansion and stopping)
         ]
         keys = self.find_keys_for_rank_lists(rank_lists, self.k)
         entries = self.create_entries(keys)
@@ -893,6 +897,33 @@ class TestCheckConvertSameSetsInvalidation(TestSetConversion):
 
         self.assertIsInstance(other.node.set, GKPlusTreeBase)
         self.assertIsNone(other.item_cnt, "other was mutated and must be invalidated")
+
+
+class TestCarriedDummyThreshold(TestSetConversion):
+    """Regression tests: conversion-threshold counting must ignore dummies
+    carried in from other dimensions.
+
+    Counting carried dummies makes the threshold unsatisfiable once enough
+    of them share a node: each expansion level keeps the lower dimensions'
+    dummies in the node's entry list and adds its own, so with K=2 and
+    l_factor=1.0 a node holding two dummies plus one real key stays above
+    the threshold forever and bulk creation recurses through dimensions
+    without bound (RecursionError).
+    """
+
+    def test_insert_keys_sharing_low_dim_ranks_terminates(self):
+        """Keys 2 and 3 have rank 1 in dimension 1 and rank 2 in dimension 2;
+        they only separate in dimension 3.  Inserting both must terminate
+        with a finite nesting depth and all invariants intact."""
+        tree = create_gkplus_tree(K=2, dimension=1, l_factor=1.0)
+        for key in (2, 3):
+            tree, _, _ = tree.insert_entry(Entry(self.make_item(key, f"val_{key}"), None), 1)
+
+        real_keys = [e.item.key for e in tree if e.item.key >= 0]
+        self.assertEqual(real_keys, [2, 3])
+        # validate_tree checks all invariants including set_thresholds_met,
+        # which uses the same carried-dummy-exempt counting rule.
+        self.validate_tree(tree)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

Inserting two keys sharing rank 1 through several dimensions into a K=2,
l_factor=1.0 GK+-tree triggers `RecursionError` in
`bulk_create_gkplus_tree` (unbounded dimensional recursion).

Repro:

```python
from gplus_trees.base import Entry, LeafItem, ItemData
from gplus_trees.g_k_plus.factory import create_gkplus_tree

tree = create_gkplus_tree(K=2, dimension=1, l_factor=1.0)
for key in (2, 3):
    tree, _, _ = tree.insert_entry(Entry(LeafItem(ItemData(key, "v")), None), 1)
```

## Root cause

The KList/GKPlusTree conversion threshold compared `item_count()`, which
includes dummies carried in from lower dimensions. Each dimensional
expansion carries forward the previous dummies and adds its own, so the
raw entry count grows by one per level regardless of how the real keys
distribute. For inputs where real keys keep colliding across several
dimensions, the threshold became unsatisfiable — the canonical structure
for such inputs would be infinitely deep.

## Fix

Only entries of a set's own dimension weigh against the threshold now:
real items (`key >= 0`) and the set's own dummy (`key == -DIM`). Dummies
carried in from other dimensions are excluded. The rule is centralized in
`bulk_create._threshold_item_count` and shared across:

- bulk creation (`_build_leaf_level_trees`, `_build_internal_levels`)
- the live expand/collapse path (`conversion.py`)
- the `set_thresholds_met` invariant (`tree_stats.py`)

so all three stay consistent — a divergence there would make the
invariant check disagree with what was actually built.

Structures without carried dummies are byte-for-byte unchanged (the new
count equals the old `item_count()` there); the full pre-existing suite
stays green.

## Testing

- New regression test reproducing the original recursion
  (`TestCarriedDummyThreshold`), asserting termination, correct keys, and
  full invariant validation via `validate_tree`.
- One pre-existing test (`test_expansion_rank_1_dim_gt_1`) sat exactly on
  the old threshold's tipping point and needed one more real key with a
  matching rank profile to keep testing its original intent under the new
  counting rule.
- `./.venv/bin/pytest` — 483 passed, 1040 subtests passed.
- `ruff format` / `ruff check` clean.
- Ad-hoc fuzz sanity (300 random keys x 3 seeds x K in {2,4,8}) confirms
  no regression in key retention or invariants outside the reported bug.

## Docs

Adds ADR-0003 recording the decision and its complexity consequences
(the conversion threshold remains O(K*l_factor) in the counted quantity;
the raw KList size may exceed it by an expected O(1) / worst-case O(log n)
number of carried dummies, bounded by the same per-dimension collision
probability the tree's height guarantee already relies on).