### PR TITLE
fix(gkplus): expansion-aware all_leaf_values_present in gtree_stats_

### DIFF
--- a/src/gplus_trees/tree_stats.py
+++ b/src/gplus_trees/tree_stats.py
@@ -42,12 +42,23 @@ def gtree_stats_(
     t: GPlusTreeBase,
     rank_hist: dict[int, int] | None = None,
     _is_root: bool = True,
+    _expect_leaf_values: bool | None = None,
 ) -> Stats:
     """
     Returns aggregated statistics for a G⁺-tree in **O(n)** time.
 
     The caller can supply an existing Counter / dict for ``rank_hist``;
     otherwise a fresh Counter is used.
+
+    ``_expect_leaf_values`` is internal recursion state: it is False for
+    inner (higher-dimension) trees that represent an *internal* node's
+    set.  Their rank-1 nodes legitimately hold value-less replicas
+    (routing structure, not data), so ``all_leaf_values_present`` stays
+    vacuously True for them instead of misreporting a violation.  The
+    default (``None``) resolves via the ``DIM`` class attribute (same
+    detection as ``check_leaf_keys_and_values``): values are expected
+    for dimension-1 Gᵏ⁺-trees and plain G⁺-trees, while an inner tree
+    validated directly on its own is exempt.
     """
     # Lazy import to break circular dependency
     from gplus_trees.klist_base import KListBase
@@ -77,6 +88,9 @@ def gtree_stats_(
             leaf_keys_in_order=True,
             inner_stats=None,
         )
+
+    if _expect_leaf_values is None:
+        _expect_leaf_values = getattr(t, "DIM", 1) == 1
 
     K = t.SetClass.KListNodeClass.CAPACITY
     threshold = t.set_conversion_threshold
@@ -115,15 +129,23 @@ def gtree_stats_(
     inner_set_stats = None
     inner_set_tree = t.inner_tree_of(node_set)
     if inner_set_tree is not None and not inner_set_tree.is_empty():
-        inner_set_stats = gtree_stats_(inner_set_tree, rank_hist=None, _is_root=True)
+        # The expanded set of an internal node (right subtree present)
+        # holds replicas, so no leaf values are expected in that inner
+        # tree; a leaf node's expanded set holds the actual data items.
+        inner_set_stats = gtree_stats_(
+            inner_set_tree,
+            rank_hist=None,
+            _is_root=True,
+            _expect_leaf_values=_expect_leaf_values and node_right_subtree is None,
+        )
 
     # ---------- recurse on children only if rank > 1 ------------------------------------
-    right_stats = gtree_stats_(node_right_subtree, rank_hist, False)
+    right_stats = gtree_stats_(node_right_subtree, rank_hist, False, _expect_leaf_values)
 
     # Only recurse on child nodes if we are at a non-leaf node indicated by the
     # presence of a right subtree
     if node_right_subtree is not None:
-        child_stats = [gtree_stats_(e.left_subtree, rank_hist, False) for e in node_set]
+        child_stats = [gtree_stats_(e.left_subtree, rank_hist, False, _expect_leaf_values) for e in node_set]
     else:
         child_stats = []
 
@@ -260,14 +282,17 @@ def gtree_stats_(
     all_inner = []
 
     if inner_set_stats is not None:
-        # Merge boolean flags from the inner tree
+        # Merge boolean flags from the inner tree.
+        # all_leaf_values_present is deliberately NOT merged: it is derived
+        # from the authoritative root-level leaf walk below, which iterates
+        # expanded leaf sets transparently.  Merging it would let inner
+        # trees of internal nodes (value-less replicas) poison the flag.
         stats.is_heap &= inner_set_stats.is_heap
         stats.is_search_tree &= inner_set_stats.is_search_tree
         stats.internal_has_replicas &= inner_set_stats.internal_has_replicas
         stats.internal_packed &= inner_set_stats.internal_packed
         stats.set_thresholds_met &= inner_set_stats.set_thresholds_met
         stats.linked_leaf_nodes &= inner_set_stats.linked_leaf_nodes
-        stats.all_leaf_values_present &= inner_set_stats.all_leaf_values_present
         stats.leaf_keys_in_order &= inner_set_stats.leaf_keys_in_order
         all_inner.append(inner_set_stats)
         # Recursively collect any deeper inner stats
@@ -296,17 +321,10 @@ def gtree_stats_(
 
     # ---------- leaf walk ONCE at the root -----------------------------
     if node_rank == 1:  # leaf node: base values
-        true_count = 0
-        all_values_present = True
-
-        for entry in node_set:
-            item = entry.item
-            if item.key >= 0:  # Skip dummy items
-                true_count += 1
-                if item.value is None:
-                    all_values_present = False
-
-        stats.all_leaf_values_present = all_values_present
+        # No per-node value check here: rank-1 nodes of inner trees under
+        # internal nodes hold value-less replicas.  Value completeness is
+        # checked by the root-level leaf walk below.
+        true_count = sum(1 for entry in node_set if entry.item.key >= 0)
         stats.real_item_count = true_count
         stats.leaf_count = 1
 
@@ -316,6 +334,7 @@ def gtree_stats_(
         leaf_count, item_count = 0, 0
         last_leaf, prev_key = None, None
         keys_in_order = True
+        all_values_present = True
         for leaf in t.iter_leaf_nodes():
             last_leaf = leaf
             leaf_count += 1
@@ -333,11 +352,16 @@ def gtree_stats_(
                     keys_in_order = False
                 prev_key = key
 
+                if item.value is None:
+                    all_values_present = False
+
                 leaf_keys.append(key)
                 leaf_values.append(item.value)
 
         # Set values from leaf traversal
         stats.leaf_keys_in_order = keys_in_order
+        if _expect_leaf_values:
+            stats.all_leaf_values_present = all_values_present
 
         # Check leaf_count and real_item_count consistency
         if leaf_count != stats.leaf_count or item_count != stats.real_item_count:

--- a/tests/gk_plus/test_tree_stats.py
+++ b/tests/gk_plus/test_tree_stats.py
@@ -1,0 +1,88 @@
+"""Regression tests for expansion-aware flags in ``gtree_stats_``."""
+
+import random
+
+from gplus_trees.g_k_plus.factory import create_gkplus_tree
+from gplus_trees.g_k_plus.g_k_plus_base import GKPlusTreeBase
+from gplus_trees.g_k_plus.utils import calc_ranks
+from gplus_trees.tree_stats import gtree_stats_
+from tests.test_base import GKPlusTreeTestCase
+
+
+class TestStatsLeafValuesExpansionAware(GKPlusTreeTestCase):
+    """``all_leaf_values_present`` must be derived from the root-level
+    leaf walk, not from per-node checks merged across inner trees.
+
+    Regression: the per-node rank-1 check treated every rank-1 node as a
+    data leaf and fired on the value-less replicas in inner trees of
+    internal nodes; the flag was then merged into the outer stats, so
+    correct GK+-trees were misreported once an internal node's set
+    expanded.  Same bug class as the ``check_leaf_keys_and_values`` fix
+    (commit c8ed7ee).
+    """
+
+    def _build_tree_with_expanded_internal_set(self):
+        """K=4, threshold 4: eight rank-2 items put 8 replicas + dummy in
+        the root's set, which therefore expands into an inner tree whose
+        rank-1 nodes hold value-less replicas — the misfire case."""
+        tree = create_gkplus_tree(K=4)
+        for key in range(1, 9):
+            tree, _, _ = tree.insert(self.make_item(key * 10, f"v{key * 10}"), rank=2)
+        self.assertIsNotNone(tree.node.right_subtree, "premise: root is an internal node")
+        self.assertIsInstance(tree.node.set, GKPlusTreeBase, "premise: internal node's set expanded")
+        return tree
+
+    def test_expanded_internal_set_keeps_flag_true(self):
+        tree = self._build_tree_with_expanded_internal_set()
+
+        stats = gtree_stats_(tree)
+
+        self.assertTrue(
+            stats.all_leaf_values_present,
+            "value-less replicas in an internal node's inner tree must not flip all_leaf_values_present",
+        )
+        self.assertEqual(stats.real_item_count, 8)
+        self.assertTrue(stats.leaf_keys_in_order)
+
+    def test_missing_leaf_value_still_flips_flag(self):
+        # The root-level walk must stay sharp: a real data item without a
+        # value in the dimension-1 leaf chain is a genuine violation.
+        tree = self._build_tree_with_expanded_internal_set()
+        nulled = False
+        for leaf in tree.iter_leaf_nodes():
+            for entry in leaf.set:
+                if entry.item.key >= 0:
+                    entry.item.value = None
+                    nulled = True
+                    break
+            if nulled:
+                break
+        self.assertTrue(nulled, "premise: found a real item to null")
+
+        stats = gtree_stats_(tree)
+
+        self.assertFalse(stats.all_leaf_values_present, "missing leaf value must flip all_leaf_values_present")
+
+    def test_repro_5000_random_keys_all_flags_hold(self):
+        # Deterministic repro: the single flagged run of the 120-run
+        # structural de-risking campaign (2026-07-06, see docs/journal/).
+        keys = random.Random(1).sample(range(1, 2**60), 5000)
+        ranks = calc_ranks(keys, 4)
+        tree = create_gkplus_tree(K=4, dimension=1, l_factor=1.0)
+        for key, rank in zip(keys, ranks, strict=True):
+            tree, _, _ = tree.insert(self.make_item(key, f"v{key}"), rank)
+
+        stats = gtree_stats_(tree)
+
+        # Ground truth via the leaf chain: every real item carries a value.
+        missing = sum(
+            1
+            for leaf in tree.iter_leaf_nodes()
+            for entry in leaf.set
+            if entry.item.key >= 0 and entry.item.value is None
+        )
+        self.assertEqual(missing, 0, "premise: leaf chain is complete")
+        self.assertTrue(stats.all_leaf_values_present, "flag must match the leaf-chain ground truth")
+        self.assertEqual(stats.real_item_count, 5000)
+        self.assertTrue(stats.leaf_keys_in_order)
+        self.assertTrue(stats.linked_leaf_nodes)


### PR DESCRIPTION
## Why

`gtree_stats_` misreported `all_leaf_values_present=False` for correct Gᵏ⁺-trees
once an **internal** node's set expanded into an inner tree. The per-node rank-1
check treated every rank-1 node as a data leaf and fired on the value-less
replicas that inner trees legitimately hold (routing structure, not data); the
inner-tree merge then propagated that flag into the outer stats. Surfaced as the
single flagged run of the 120-run structural de-risking campaign (2026-07-06,
see `docs/journal/2026-07-06-gk-structural-derisk.md`).

Same bug class as c8ed7ee, which made `check_leaf_keys_and_values` in
`invariants.py` expansion-aware but did not touch the equivalent flag in
`tree_stats.py`.

Verification surfaced a **second, opposite defect** in the old path: the per-node
flag was never aggregated across child/right subtrees (unlike `is_heap` & co.),
so a genuinely missing leaf value in a multi-node tree went **undetected** — a
silent false negative. The fix closes both directions.

## What

- `all_leaf_values_present` is now derived solely from the authoritative
  root-level `iter_leaf_nodes()` walk, which iterates expanded leaf sets
  transparently and covers exactly the data items of the dimension-1 leaf chain.
  The per-node value check and the inner-tree merge of the flag are removed.
- Inner trees representing an internal node's set are exempt via new recursion
  state `_expect_leaf_values`. Its top-level default resolves through the `DIM`
  class attribute — the same detection as `check_leaf_keys_and_values` — so a
  higher-dimension tree validated standalone (replicas, no values) stays
  vacuously `True`, while dimension-1 Gᵏ⁺-trees and plain G⁺-trees keep the check.
- Regression tests in `tests/gk_plus/test_tree_stats.py`.

## How to verify

- `pytest tests/gk_plus/test_tree_stats.py` — the deterministic 5000-key repro
  reports all flags ok; an expanded internal-node set keeps the flag `True`; a
  nulled leaf value still flips it (the previously undetected case, red on
  pre-fix code).
- Full suite (536 tests) and `ruff check .` / `ruff format --check .` green.
