### PR TITLE
chore(ci): lean CI to single supported Python (3.11) with aggregate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
       - run: pip install ruff
       - name: Ruff lint
         run: ruff check .
@@ -25,17 +25,29 @@ jobs:
         run: ruff format --check .
 
   test:
-    name: Tests (Python ${{ matrix.python-version }})
+    name: Tests (Python 3.11)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
       - run: pip install -e .
       - run: pip install numpy tqdm pytest
       - name: Run tests
         run: pytest -v
+
+  # Aggregate gate: the single check required by the branch ruleset.
+  # Requiring this one context (instead of each job by name) keeps branch
+  # protection decoupled from the job list — add or rename jobs without
+  # touching the ruleset. Fails if any needed job failed or was cancelled.
+  ci:
+    name: CI
+    if: always()
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any dependency did not succeed
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1
+      - run: echo "all required jobs green"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.13"
+python = ">=3.11,<3.12"
 numpy = "^2.2.5"
 tqdm = "^4.67.1"
 
@@ -31,7 +31,7 @@ build-backend = "poetry.core.masonry.api"
 
 # ── Ruff (linter + formatter) ──────────────────────────────────────
 [tool.ruff]
-target-version = "py310"
+target-version = "py311"
 line-length = 120
 src = ["src", "tests", "stats", "scripts"]
 
@@ -59,7 +59,7 @@ known-first-party = ["gplus_trees", "tests"]
 # The mixin-based architecture causes widespread attr-defined / union-attr
 # false positives. Re-enable in CI after adding Protocol stubs.
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = false


### PR DESCRIPTION
## Why

The project is developed and run on Python 3.11 only. The CI matrix tested
3.10–3.12 and `pyproject.toml` declared `>=3.10,<3.13`, promising a portability
window that is never actually exercised. Testing what isn't promised (and
promising what isn't tested) is the incoherent case — this narrows both to the
one version in real use.

Separately, branch protection required each CI job by name (`Lint (ruff)`,
`Tests (Python 3.10/3.11/3.12)`). That couples the ruleset to the job list:
renaming a job or changing the matrix strands PRs on a phantom "pending" check.

## What

- **Support window → 3.11 only:** `python = ">=3.11,<3.12"`, ruff
  `target-version = "py311"`, mypy `python_version = "3.11"`, and a single
  `Tests (Python 3.11)` job (matrix removed). Lint pinned to 3.11 too.
- **Aggregate `CI` gate job:** a new job that `needs: [lint, test]` and fails if
  either did not succeed. Branch protection now requires only the single `CI`
  context, decoupling the ruleset from the job list — jobs can be added or
  renamed without touching protection.

The merge model is unchanged (agents propose via PR, human reviews and merges;
0 required approvals). The `CI` gate is the automatic backstop against a broken
change reaching `main`.

## How to verify

- `ruff check .` / `ruff format --check .` and `pytest` (536 tests) pass on
  Python 3.11.9.
- On this PR: the `CI` check aggregates `lint` + `test` and must be green to
  merge; direct pushes to `main` and force-pushes remain blocked.
