### PR TITLE
docs: record code provenance convention for experiment runners

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ Agent entrypoint: invariants and pointers only. Human documentation lives in
 - Decisions + rationale: `docs/adr/`. Experiment findings are kept machine-local under
   `.scratch/` (not tracked in git).
 - Fixture provenance: `benchmarks/adversarial_keys/PROVENANCE.md`.
+- Experiment runners record per-row code provenance: `code_sha` (short git HEAD) and
+  `code_src` (runtime `gplus_trees.__file__`).
 
 ## Agent scaffolding
 


### PR DESCRIPTION
## Why

A recent structural de-risking campaign produced a results CSV with no
code-state column, so its measurements could not be attributed to a
commit after the fact — confirming which code state produced them
required a full differential re-run against two code states instead of
a quick lookup. That's avoidable: a code-state column costs nothing to
record up front.

## What

Adds one line to the Knowledge layer section of `CLAUDE.md`, stating the
convention as an invariant: experiment runners record per-row code
provenance — `code_sha` (short git HEAD) and `code_src` (runtime
`gplus_trees.__file__`) — alongside their measurements.

## How to verify

- Read the Knowledge layer section of `CLAUDE.md` for the new line.
- `./.venv/bin/ruff check .` and `./.venv/bin/ruff format --check .` are
  green.
- `./.venv/bin/pytest` is green (542 passed).
