### PR TITLE
feat(adversarial): mixed-rank key-set generator for worst-case height probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ python tests/test_runner.py --log-level INFO  # custom runner with logging
 
 ## Project layout
 - [src/gplus_trees/](src/gplus_trees/): core implementations and factories for G+ and GK+ trees.
+- [adversarial/](adversarial/): mixed-rank adversarial key-set generator (per-dimension rank profiles, verified against the rank calculation) for worst-case structure probes.
 - [benchmarks/](benchmarks/): isolated ASV-based performance measurements (see [benchmarks/BENCHMARKS.md](benchmarks/BENCHMARKS.md)).
 - [stats/](stats/): scripts for measuring structure statistics across parameters.
 - [scripts/](scripts/): adversarial-key discovery and analysis tools.

--- a/adversarial/__init__.py
+++ b/adversarial/__init__.py
@@ -1,0 +1,32 @@
+"""Adversarial key-set construction for Gᵏ⁺ worst-case structure probes.
+
+Produces key sets with engineered per-dimension rank profiles — beyond the
+uniform rank-1 pile-up of the frozen fixtures (see
+``benchmarks/adversarial_keys/PROVENANCE.md``) — and verifies every
+constructed set against the authoritative rank calculation before handing
+it out. The uniform rank-1 reference search stays in
+``scripts/find_adversarial_keys.py``; this package covers the mixed-rank
+shape families used by the height-bound probes.
+"""
+
+from adversarial.mixed_rank import (
+    MixedRankKeySet,
+    ProfileMismatch,
+    collide_then_diversify,
+    find_key_with_profile,
+    front_loaded_spine,
+    parallel_blocks,
+    staircase,
+    verify_profiles,
+)
+
+__all__ = [
+    "MixedRankKeySet",
+    "ProfileMismatch",
+    "collide_then_diversify",
+    "find_key_with_profile",
+    "front_loaded_spine",
+    "parallel_blocks",
+    "staircase",
+    "verify_profiles",
+]

--- a/adversarial/mixed_rank.py
+++ b/adversarial/mixed_rank.py
@@ -1,0 +1,303 @@
+"""Mixed-rank adversarial key-set generator for Gᵏ⁺ height probes.
+
+A Gᵏ⁺-tree defends against rank-1 pile-ups by converting an oversized
+G-node set into a tree of the next-deeper dimension. Reaching depth d
+therefore needs rank-1 collisions per dimension, while height *within* a
+dimension needs rank diversity — two demands that compete for the same
+keys. The shape families here occupy the middle ground between the two
+pure strategies: each combines a fat rank-1 pile (drives conversion depth)
+with thin engineered rank spines (drive per-dimension G-node paths).
+
+Every constructor verifies the finished key set against the authoritative
+rank calculation (``calc_ranks_multi_dims``) before returning it; the
+search loop itself is never trusted.
+
+Key-space layout: each engineered key is searched inside its own slot of
+width ``SLOT_STRIDE``, slots ascending in the order the keys must appear.
+Rank profiles only constrain *which* keys qualify; the slot layout
+controls their relative order, which is what makes a rank-1 run
+contiguous (one G-node) and places spine keys on the G-node path to it.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+
+from gplus_trees.g_k_plus.utils import calc_ranks_multi_dims
+from gplus_trees.utils import calc_rank_from_digest, get_group_size
+
+# One entry per dimension, starting at dimension 1; None = unconstrained.
+Profile = tuple[int | None, ...]
+
+# Slots start above every frozen fixture key (those grow upward from 1)
+# and stay far below the 2**60 ceiling of the random-baseline key draw:
+# even hundreds of slots keep keys < 2**53.
+KEY_BASE = 1 << 44
+SLOT_STRIDE = 1 << 44
+
+
+class ProfileMismatch(AssertionError):
+    """A constructed key's recomputed ranks contradict its required profile."""
+
+
+def find_key_with_profile(
+    profile: Sequence[int | None],
+    k: int,
+    *,
+    start_key: int,
+    end_key: int | None = None,
+    max_candidates: int = 500_000_000,
+) -> int:
+    """Smallest key ≥ ``start_key`` whose per-dimension ranks match ``profile``.
+
+    ``profile[i]`` is the required rank in dimension i+1; None leaves that
+    dimension unconstrained. The digest chain mirrors the authoritative
+    ``gplus_trees.utils.get_digest``: dimension 1 hashes the key, dimension
+    d+1 hashes the dimension-d digest. Expected search cost is dominated by
+    the profile's largest rank r (≈ k^(r-1) candidates) and its rank-1
+    prefix length j (≈ (k/(k-1))^j survival factor).
+
+    Raises LookupError when ``end_key`` or ``max_candidates`` is exhausted.
+    """
+    if start_key < 1:
+        raise ValueError("start_key must be ≥ 1 (0 is reserved as the non-existing split key)")
+    group_size = get_group_size(k)
+    dim_bytes = [d.to_bytes(32, "big") for d in range(1, len(profile) + 1)]
+    sha = hashlib.sha256
+    # Hot-loop shortcut for the dominant rank-1 checks: rank 1 means fewer
+    # than group_size trailing zero bits, i.e. the digest's last byte has a
+    # set bit inside the low group_size bits. Only valid for group_size ≤ 8
+    # (k ≤ 256); rarer ranks and larger k stay on the authoritative
+    # calc_rank_from_digest. Found keys are re-verified against the
+    # authoritative calculation by verify_profiles either way.
+    low_mask = (1 << group_size) - 1 if group_size <= 8 else 0
+    key = start_key
+    for _ in range(max_candidates):
+        if end_key is not None and key >= end_key:
+            break
+        digest = sha(key.to_bytes(32, "big") + dim_bytes[0]).digest()
+        matched = True
+        for i, want in enumerate(profile):
+            if i:
+                digest = sha(digest + dim_bytes[i]).digest()
+            if want is None:
+                continue
+            if want == 1 and low_mask:
+                if digest[-1] & low_mask:
+                    continue
+                matched = False
+                break
+            if calc_rank_from_digest(digest, group_size) != want:
+                matched = False
+                break
+        if matched:
+            return key
+        key += 1
+    raise LookupError(
+        f"no key matching profile {tuple(profile)} in [{start_key}, {end_key}) after {key - start_key} candidates"
+    )
+
+
+def verify_profiles(keys: Sequence[int], profiles: Sequence[Profile], k: int) -> None:
+    """Check every key's recomputed ranks against its required profile.
+
+    Recomputes with the authoritative ``calc_ranks_multi_dims`` — this is
+    the independent check that lets callers treat generated key sets as
+    ground truth rather than trusting the search loop.
+    """
+    if len(keys) != len(profiles):
+        raise ValueError("keys and profiles must align")
+    dims = max(len(p) for p in profiles)
+    rank_lists = calc_ranks_multi_dims(list(keys), k, dims)
+    for idx, profile in enumerate(profiles):
+        for dim_idx, want in enumerate(profile):
+            got = rank_lists[dim_idx][idx]
+            if want is not None and got != want:
+                raise ProfileMismatch(
+                    f"key {keys[idx]} (index {idx}): dimension {dim_idx + 1} has rank {got}, profile requires {want}"
+                )
+
+
+@dataclass(frozen=True)
+class MixedRankKeySet:
+    """A verified adversarial key set plus the rank profiles it satisfies.
+
+    ``keys`` are strictly ascending and meant to be inserted in this order
+    (history independence makes the order irrelevant to the resulting
+    tree; ascending keeps campaigns comparable). ``profiles[i]`` is the
+    constraint ``keys[i]`` was searched for and verified against.
+    """
+
+    family: str
+    label: str
+    k: int
+    depth: int
+    params: dict
+    keys: tuple[int, ...]
+    profiles: tuple[Profile, ...]
+
+    def verify(self) -> None:
+        verify_profiles(self.keys, self.profiles, self.k)
+
+    def shrink_pile(self, pile_size: int) -> MixedRankKeySet:
+        """Same shape with the rank-1 pile truncated to its smallest ``pile_size`` keys.
+
+        Valid because the pile keys are the largest keys of the set and all
+        share one profile: dropping keys from the top preserves ordering,
+        the pile's contiguity, and every remaining profile. Lets one
+        expensive spine search serve a whole n-sweep.
+        """
+        old_size = self.params.get("pile_size")
+        if old_size is None:
+            raise ValueError(f"family {self.family!r} has no shrinkable pile")
+        if not 0 < pile_size <= old_size:
+            raise ValueError(f"pile_size must be in (0, {old_size}], got {pile_size}")
+        cut = old_size - pile_size
+        keep = len(self.keys) - cut
+        return replace(
+            self,
+            keys=self.keys[:keep],
+            profiles=self.profiles[:keep],
+            params={**self.params, "pile_size": pile_size},
+        )
+
+
+def _slot_starts():
+    """Ascending search-slot start keys, one slot per engineered key group."""
+    slot = 0
+    while True:
+        yield KEY_BASE + slot * SLOT_STRIDE
+        slot += 1
+
+
+def _find_block(count: int, profile: Profile, k: int, slot_start: int) -> list[int]:
+    """``count`` consecutive-slot keys matching one shared profile."""
+    keys = []
+    next_start = slot_start
+    for _ in range(count):
+        key = find_key_with_profile(profile, k, start_key=next_start, end_key=slot_start + SLOT_STRIDE)
+        keys.append(key)
+        next_start = key + 1
+    return keys
+
+
+def _build(
+    family: str, label: str, k: int, depth: int, params: dict, entries: list[tuple[int, Profile]]
+) -> MixedRankKeySet:
+    """Assemble, order-check, and verify a key set from (key, profile) pairs."""
+    keys = tuple(key for key, _ in entries)
+    if list(keys) != sorted(set(keys)):
+        raise ValueError("slot layout produced non-ascending or duplicate keys")
+    key_set = MixedRankKeySet(
+        family=family,
+        label=label,
+        k=k,
+        depth=depth,
+        params=params,
+        keys=keys,
+        profiles=tuple(profile for _, profile in entries),
+    )
+    key_set.verify()
+    return key_set
+
+
+def staircase(
+    k: int,
+    depth: int,
+    spine_heights: int | Sequence[int],
+    pile_size: int,
+    *,
+    family: str = "staircase",
+    label: str | None = None,
+) -> MixedRankKeySet:
+    """Nested-spine staircase: engineered G-node path above the pile in every dimension.
+
+    Per dimension j ≤ depth, ``spine_heights[j-1]`` spine keys carry ranks
+    s+1 … 2 at dimension j (descending as keys ascend, so each spine node's
+    right subtree leads toward the pile) and rank 1 in every dimension
+    before j (so they survive inside all outer converted sets). The pile —
+    ``pile_size`` keys, rank 1 through all ``depth`` dimensions — is the
+    rightmost block; every carried entry of an outer dimension sorts left
+    of the inner spine, so it can branch off but never interpose on the
+    path to the pile.
+
+    A uniform ``spine_heights=s`` probes multiplicative growth
+    (≈ (s+1)·depth); front-loaded profiles probe one-off additive gains.
+    """
+    if isinstance(spine_heights, int):
+        spine_heights = [spine_heights] * depth
+    if len(spine_heights) != depth:
+        raise ValueError(f"spine_heights must have one entry per dimension, got {len(spine_heights)} for depth {depth}")
+    if label is None:
+        label = f"{family}_s{max(spine_heights)}"
+
+    slots = _slot_starts()
+    entries: list[tuple[int, Profile]] = []
+    for dim_idx, height in enumerate(spine_heights):  # dim_idx 0 = dimension 1
+        for rank in range(height + 1, 1, -1):
+            profile: Profile = (1,) * dim_idx + (rank,)
+            key = find_key_with_profile(profile, k, start_key=next(slots))
+            entries.append((key, profile))
+    pile_profile: Profile = (1,) * depth
+    entries += [(key, pile_profile) for key in _find_block(pile_size, pile_profile, k, next(slots))]
+
+    params = {"spine_heights": list(spine_heights), "pile_size": pile_size}
+    return _build(family, label, k, depth, params, entries)
+
+
+def front_loaded_spine(k: int, depth: int, spine_height: int, pile_size: int) -> MixedRankKeySet:
+    """Staircase variant with the whole spine budget in dimension 1 only.
+
+    Probes the additive combination: one dimension of engineered height on
+    top of a pure pile-up below it — the sum shape O(spine + depth), as
+    opposed to the uniform staircase's product shape.
+    """
+    heights = [spine_height] + [0] * (depth - 1)
+    return staircase(k, depth, heights, pile_size, family="front", label=f"front_s{spine_height}")
+
+
+def collide_then_diversify(k: int, depth: int, bottom_spine_height: int, pile_size: int) -> MixedRankKeySet:
+    """Pure pile-up to ``depth``, then an engineered spine at dimension depth+1.
+
+    All keys collide (rank 1) through dimensions 1…depth; at the bottom
+    dimension the spine keys carry ranks s+1 … 2 left of the bulk, whose
+    ranks there are unconstrained (hash-random). Probes how tall a single
+    dimension can be driven *at the bottom of* a maximal pile-up — the
+    issue's "collide to depth j, then diversify" staircase profile.
+    """
+    slots = _slot_starts()
+    entries: list[tuple[int, Profile]] = []
+    for rank in range(bottom_spine_height + 1, 1, -1):
+        profile: Profile = (1,) * depth + (rank,)
+        key = find_key_with_profile(profile, k, start_key=next(slots))
+        entries.append((key, profile))
+    bulk_profile: Profile = (1,) * depth
+    entries += [(key, bulk_profile) for key in _find_block(pile_size, bulk_profile, k, next(slots))]
+
+    params = {"bottom_spine_height": bottom_spine_height, "pile_size": pile_size}
+    return _build("dive", f"dive_s{bottom_spine_height}", k, depth, params, entries)
+
+
+def parallel_blocks(k: int, depth: int, n_blocks: int, block_size: int, *, separator_rank: int = 2) -> MixedRankKeySet:
+    """Independent rank-1 piles separated at dimension 1 — the parallelism control.
+
+    ``n_blocks`` piles of ``block_size`` keys (rank 1 through ``depth``),
+    kept apart by single keys of rank ``separator_rank`` at dimension 1.
+    Each pile converts and recurses on its own; nesting-aware height is a
+    maximum over branches, so this family should buy no height over a
+    single pile of ``block_size`` — measuring that is its purpose.
+    """
+    slots = _slot_starts()
+    entries: list[tuple[int, Profile]] = []
+    block_profile: Profile = (1,) * depth
+    separator_profile: Profile = (separator_rank,)
+    for block_idx in range(n_blocks):
+        entries += [(key, block_profile) for key in _find_block(block_size, block_profile, k, next(slots))]
+        if block_idx < n_blocks - 1:
+            key = find_key_with_profile(separator_profile, k, start_key=next(slots))
+            entries.append((key, separator_profile))
+
+    params = {"n_blocks": n_blocks, "block_size": block_size, "separator_rank": separator_rank}
+    return _build("blocks", f"blocks_b{n_blocks}", k, depth, params, entries)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.ruff]
 target-version = "py311"
 line-length = 120
-src = ["src", "tests", "stats", "scripts"]
+src = ["src", "tests", "stats", "scripts", "adversarial"]
 
 [tool.ruff.lint]
 select = [
@@ -52,7 +52,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.isort]
-known-first-party = ["gplus_trees", "tests"]
+known-first-party = ["gplus_trees", "tests", "adversarial"]
 
 # ── Mypy (type checker) ────────────────────────────────────────────
 # NOTE: mypy is available locally but not enforced in CI.

--- a/tests/adversarial/test_mixed_rank.py
+++ b/tests/adversarial/test_mixed_rank.py
@@ -1,0 +1,166 @@
+"""Tests for the mixed-rank adversarial key-set generator.
+
+Rank assertions here recompute ranks with the authoritative
+``calc_ranks_multi_dims`` instead of trusting the generator's own
+verification — the acceptance bar is "verified against the rank
+calculation, not assumed".
+"""
+
+import pytest
+
+from adversarial import (
+    ProfileMismatch,
+    collide_then_diversify,
+    find_key_with_profile,
+    front_loaded_spine,
+    parallel_blocks,
+    staircase,
+    verify_profiles,
+)
+from adversarial.mixed_rank import KEY_BASE
+from gplus_trees.base import ItemData, LeafItem
+from gplus_trees.g_k_plus.factory import make_gkplustree_classes
+from gplus_trees.g_k_plus.utils import calc_ranks, calc_ranks_multi_dims
+from gplus_trees.tree_stats import gtree_stats_
+
+K = 4
+
+
+def ranks_of(key: int, dims: int) -> list[int]:
+    """Authoritative per-dimension ranks of a single key."""
+    rank_lists = calc_ranks_multi_dims([key], K, dims)
+    return [rank_lists[dim][0] for dim in range(dims)]
+
+
+class TestFindKeyWithProfile:
+    def test_found_key_matches_requested_profile(self):
+        for profile in [(2,), (1, 2), (1, 1, 3), (4,)]:
+            key = find_key_with_profile(profile, K, start_key=1)
+            assert ranks_of(key, len(profile)) == list(profile)
+
+    def test_respects_start_key_and_wildcard(self):
+        key = find_key_with_profile((None, 2), K, start_key=KEY_BASE)
+        assert key >= KEY_BASE
+        assert ranks_of(key, 2)[1] == 2
+
+    def test_deterministic(self):
+        args = ((1, 1, 2), K)
+        assert find_key_with_profile(*args, start_key=1) == find_key_with_profile(*args, start_key=1)
+
+    def test_raises_when_range_exhausted(self):
+        with pytest.raises(LookupError):
+            find_key_with_profile((12,), K, start_key=KEY_BASE, end_key=KEY_BASE + 50)
+
+    def test_rejects_reserved_key_zero(self):
+        with pytest.raises(ValueError):
+            find_key_with_profile((1,), K, start_key=0)
+
+
+class TestVerifyProfiles:
+    def test_detects_mismatch(self):
+        key = find_key_with_profile((1,), K, start_key=1)
+        with pytest.raises(ProfileMismatch):
+            verify_profiles([key], [(2,)], K)
+
+    def test_accepts_matching_and_wildcard(self):
+        key = find_key_with_profile((2, 1), K, start_key=1)
+        verify_profiles([key], [(2, None)], K)
+
+
+class TestStaircase:
+    def test_ranks_and_ordering_verified_independently(self):
+        depth, spine, pile = 3, 2, 12
+        key_set = staircase(K, depth, spine, pile_size=pile)
+        keys = list(key_set.keys)
+        assert keys == sorted(set(keys))
+        assert len(keys) == depth * spine + pile
+
+        rank_lists = calc_ranks_multi_dims(keys, K, depth)
+        for dim_idx in range(depth):  # spine of dimension dim_idx+1
+            lo = dim_idx * spine
+            spine_ranks = [rank_lists[dim_idx][i] for i in range(lo, lo + spine)]
+            assert spine_ranks == [3, 2], f"dimension {dim_idx + 1} spine must descend toward the pile"
+            for outer_dim in range(dim_idx):
+                assert all(rank_lists[outer_dim][i] == 1 for i in range(lo, lo + spine))
+        pile_lo = depth * spine
+        for dim_idx in range(depth):
+            assert all(rank_lists[dim_idx][i] == 1 for i in range(pile_lo, len(keys)))
+        assert max(keys[:pile_lo]) < min(keys[pile_lo:]), "pile must be the rightmost key block"
+
+    def test_shrink_pile(self):
+        key_set = staircase(K, 2, 1, pile_size=12)
+        smaller = key_set.shrink_pile(5)
+        assert smaller.keys == key_set.keys[: 2 + 5]
+        assert smaller.profiles == key_set.profiles[: 2 + 5]
+        assert smaller.params["pile_size"] == 5
+        smaller.verify()
+        with pytest.raises(ValueError):
+            key_set.shrink_pile(0)
+        with pytest.raises(ValueError):
+            key_set.shrink_pile(13)
+
+    def test_front_loaded_spine_only_in_dimension_one(self):
+        depth, spine, pile = 3, 2, 8
+        key_set = front_loaded_spine(K, depth, spine, pile_size=pile)
+        assert len(key_set.keys) == spine + pile
+        rank_lists = calc_ranks_multi_dims(list(key_set.keys), K, depth)
+        assert [rank_lists[0][0], rank_lists[0][1]] == [3, 2]
+        for dim_idx in range(depth):
+            assert all(rank_lists[dim_idx][i] == 1 for i in range(spine, spine + pile))
+
+
+class TestParallelBlocks:
+    def test_blocks_and_separators(self):
+        depth, n_blocks, block_size = 2, 3, 6
+        key_set = parallel_blocks(K, depth, n_blocks, block_size)
+        keys = list(key_set.keys)
+        assert len(keys) == n_blocks * block_size + (n_blocks - 1)
+        assert keys == sorted(set(keys))
+
+        rank_lists = calc_ranks_multi_dims(keys, K, depth)
+        pos = 0
+        for block_idx in range(n_blocks):
+            for dim_idx in range(depth):
+                assert all(rank_lists[dim_idx][i] == 1 for i in range(pos, pos + block_size))
+            pos += block_size
+            if block_idx < n_blocks - 1:
+                assert rank_lists[0][pos] == 2, "separator must split blocks at dimension 1"
+                pos += 1
+
+
+class TestCollideThenDiversify:
+    def test_bottom_spine_below_full_pile(self):
+        depth, spine, pile = 2, 3, 8
+        key_set = collide_then_diversify(K, depth, spine, pile_size=pile)
+        keys = list(key_set.keys)
+        assert len(keys) == spine + pile
+
+        rank_lists = calc_ranks_multi_dims(keys, K, depth + 1)
+        for dim_idx in range(depth):
+            assert all(rank_lists[dim_idx][i] == 1 for i in range(len(keys)))
+        bottom = [rank_lists[depth][i] for i in range(spine)]
+        assert bottom == [4, 3, 2], "bottom spine must descend toward the bulk"
+
+
+class TestTreeIntegration:
+    def test_staircase_drives_conversion_depth(self):
+        """The generated keys must actually reach the engineered nesting depth."""
+        depth = 2
+        key_set = staircase(K, depth, 1, pile_size=20)
+        tree_cls, _, _, _ = make_gkplustree_classes(K)
+        tree = tree_cls(l_factor=1.0)
+        keys = list(key_set.keys)
+        for item, rank in zip(
+            (LeafItem(ItemData(key, f"value_{key}")) for key in keys),
+            calc_ranks(keys, K),
+            strict=True,
+        ):
+            tree, _, _ = tree.insert(item, rank)
+
+        assert tree.get_max_dim() >= depth + 1, "pile must convert through every engineered dimension"
+        stats = gtree_stats_(tree)
+        assert stats.real_item_count == len(keys)
+        # Deliberately not asserted: all_leaf_values_present — known checker
+        # false positive on converted inner trees (c8ed7ee follow-up issue).
+        for flag in ("is_heap", "is_search_tree", "leaf_keys_in_order", "linked_leaf_nodes"):
+            assert getattr(stats, flag), f"invariant {flag} violated"


### PR DESCRIPTION
## Why

The structural derisk campaign (2026-07-06) showed additive height growth
h ≈ 1.25·d + O(log n) under pure rank-1 pile-up adversarial keys — strictly
below the thesis's proven O(log²n) upper bound. Whether a mixed-rank
construction (rank diversity within a dimension, not just successive
rank-1 hits) can force superadditive growth was open, and the answer
decides the planned paper's headline theorem.

## What

Adds `adversarial/`, a tracked package for constructing key sets with
engineered per-dimension rank profiles:

- `find_key_with_profile`: searches for the smallest key matching an exact
  per-dimension rank profile (extends the existing uniform rank-1 search
  in `scripts/find_adversarial_keys.py` to arbitrary, mixed profiles).
- `verify_profiles` / `MixedRankKeySet.verify`: every constructed key set
  is checked against the authoritative `calc_ranks_multi_dims` before use
  — never assumed from the search loop.
- Four shape families probing the depth-vs-height tension: `staircase`
  (per-dimension spine + rank-1 pile, product-shape probe), `front_loaded_spine`
  (sum-shape probe), `collide_then_diversify` (bottom-dimension spine after
  a full pile-up), `parallel_blocks` (parallelism control).

Unit tests (`tests/adversarial/test_mixed_rank.py`) assert rank profiles
independently and include a tree-integration test confirming a staircase
set actually drives conversion through every engineered dimension.

The uniform rank-1 reference search stays in `scripts/find_adversarial_keys.py`,
unchanged.

## How to verify

```
./.venv/bin/pytest tests/adversarial/ -v
./.venv/bin/ruff check adversarial/ tests/adversarial/
./.venv/bin/ruff format --check adversarial/ tests/adversarial/
```

Full suite unaffected: `./.venv/bin/pytest -q` (555 passed, 1040 subtests).
